### PR TITLE
Misc fixes, improve __str__ and __repr__

### DIFF
--- a/flopy4/array.py
+++ b/flopy4/array.py
@@ -219,12 +219,16 @@ class MFArray(MFParam, NumPyArrayMixin):
             repeating=repeating,
             tagged=tagged,
             reader=reader,
+            shape=shape,
             default_value=default_value,
         )
         self._value = array
         self._shape = shape
         self._how = how
         self._factor = factor
+
+    def __get__(self, obj, type=None):
+        return self if self.value is None else self.value
 
     def __getitem__(self, item):
         return self.raw[item]
@@ -269,10 +273,13 @@ class MFArray(MFParam, NumPyArrayMixin):
         return self
 
     @property
-    def value(self) -> np.ndarray:
+    def value(self) -> Optional[np.ndarray]:
         """
         Return the array.
         """
+        if self._value is None:
+            return None
+
         if self.layered:
             arr = []
             for mfa in self._value:
@@ -283,6 +290,11 @@ class MFArray(MFParam, NumPyArrayMixin):
             return np.ones(self._shape) * self._value * self.factor
         else:
             return self._value.reshape(self._shape) * self.factor
+
+    @value.setter
+    def value(self, value: np.ndarray):
+        assert value.shape == self.shape
+        self._value = value
 
     @property
     def raw(self):

--- a/flopy4/block.py
+++ b/flopy4/block.py
@@ -2,6 +2,7 @@ from abc import ABCMeta
 from collections import UserDict
 from dataclasses import asdict
 from io import StringIO
+from pprint import pformat
 from typing import Any
 
 from flopy4.array import MFArray
@@ -85,6 +86,9 @@ class MFBlock(MFParams, metaclass=MFBlockMappingMeta):
         # the class attribute is the full parameter instance.
         attr = super().__getattribute__(name)
         return attr.value if isinstance(attr, MFParam) else attr
+
+    def __repr__(self):
+        return pformat(self.data)
 
     def __str__(self):
         buffer = StringIO()

--- a/flopy4/compound.py
+++ b/flopy4/compound.py
@@ -55,6 +55,9 @@ class MFCompound(MFParam, MFParams):
             default_value,
         )
 
+    def __get__(self, obj, type=None):
+        return self
+
     def __repr__(self):
         return pformat(self.data)
 

--- a/flopy4/compound.py
+++ b/flopy4/compound.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 from collections.abc import Mapping
 from dataclasses import asdict
 from io import StringIO
+from pprint import pformat
 from typing import Any, Dict
 
 from flopy4.param import MFParam, MFParams, MFReader
@@ -54,6 +55,9 @@ class MFCompound(MFParam, MFParams):
             default_value,
         )
 
+    def __repr__(self):
+        return pformat(self.data)
+
     @property
     def params(self) -> MFParams:
         """Component parameters."""
@@ -67,14 +71,10 @@ class MFCompound(MFParam, MFParams):
         }
 
     @value.setter
-    def value(self, **kwargs):
+    def value(self, value):
         """Set component names/values by keyword arguments."""
-        val_len = len(kwargs)
-        exp_len = len(self.data)
-        if exp_len != val_len:
-            raise ValueError(f"Expected {exp_len} values, got {val_len}")
-        for key in self.data.keys():
-            self.data[key].value = kwargs[key]
+        for key, val in value.items():
+            self.data[key].value = val
 
 
 class MFRecord(MFCompound):
@@ -224,5 +224,4 @@ class MFKeystring(MFCompound):
 
     def write(self, f):
         """Write the keystring to file."""
-        for param in self.data:
-            param.write(f)
+        super().write(f)

--- a/flopy4/package.py
+++ b/flopy4/package.py
@@ -17,9 +17,8 @@ def get_block(pkg_name, block_name, params):
 
 class MFPackageMeta(type):
     def __new__(cls, clsname, bases, attrs):
-        new = super().__new__(cls, clsname, bases, attrs)
         if clsname == "MFPackage":
-            return new
+            return super().__new__(cls, clsname, bases, attrs)
 
         # detect package name
         pkg_name = clsname.replace("Package", "")
@@ -34,8 +33,7 @@ class MFPackageMeta(type):
                 if issubclass(type(v), MFParam)
             }
         )
-        new.params = params
-        new.blocks = MFBlocks(
+        blocks = MFBlocks(
             {
                 block_name: get_block(
                     pkg_name=pkg_name,
@@ -47,7 +45,13 @@ class MFPackageMeta(type):
                 )
             }
         )
-        return new
+
+        attrs["params"] = params
+        attrs["blocks"] = blocks
+        for block_name, block in blocks.items():
+            attrs[block_name] = block
+
+        return super().__new__(cls, clsname, bases, attrs)
 
 
 class MFPackageMappingMeta(MFPackageMeta, ABCMeta):

--- a/flopy4/package.py
+++ b/flopy4/package.py
@@ -2,6 +2,7 @@ from abc import ABCMeta
 from collections import UserDict
 from io import StringIO
 from itertools import groupby
+from pprint import pformat
 from typing import Any
 
 from flopy4.block import MFBlock, MFBlockMeta, MFBlocks
@@ -57,9 +58,11 @@ class MFPackage(UserDict, metaclass=MFPackageMappingMeta):
     """
     MF6 model or simulation component package.
 
-
     TODO: reimplement with `ChainMap`?
     """
+
+    def __repr__(self):
+        return pformat(self.data)
 
     def __str__(self):
         buffer = StringIO()

--- a/flopy4/package.py
+++ b/flopy4/package.py
@@ -1,5 +1,4 @@
 from abc import ABCMeta
-from collections import UserDict
 from io import StringIO
 from itertools import groupby
 from pprint import pformat
@@ -22,10 +21,12 @@ class MFPackageMeta(type):
         if clsname == "MFPackage":
             return new
 
+        # detect package name
+        pkg_name = clsname.replace("Package", "")
+
         # add parameter and block specification as class
         # attributes. subclass mfblock dynamically based
         # on each block parameter specification.
-        pkg_name = clsname.replace("Package", "")
         params = MFParams(
             {
                 k: v.with_name(k)
@@ -54,12 +55,15 @@ class MFPackageMappingMeta(MFPackageMeta, ABCMeta):
     pass
 
 
-class MFPackage(UserDict, metaclass=MFPackageMappingMeta):
+class MFPackage(MFBlocks, metaclass=MFPackageMappingMeta):
     """
     MF6 model or simulation component package.
 
     TODO: reimplement with `ChainMap`?
     """
+
+    def __init__(self, blocks=None):
+        super().__init__(blocks)
 
     def __repr__(self):
         return pformat(self.data)
@@ -70,29 +74,25 @@ class MFPackage(UserDict, metaclass=MFPackageMappingMeta):
         return buffer.getvalue()
 
     def __getattribute__(self, name: str) -> Any:
-        value = super().__getattribute__(name)
         if name == "data":
-            return value
+            return super().__getattribute__(name)
+
+        block = self.data.get(name)
+        if block is not None:
+            return block
 
         # shortcut to parameter value for instance attribute.
-        # the class attribute is the full parameter instance.
+        # the class attribute is the parameter specification.
         params = {
             param_name: param
             for block in self.data.values()
             for param_name, param in block.items()
         }
         param = params.get(name)
-        return params[name].value if param is not None else value
-
-    @property
-    def params(self) -> MFParams:
-        """Package parameters."""
-        return MFParams(
-            {
-                name: param
-                for block in self.data
-                for name, param in block.items()
-            }
+        return (
+            param.value
+            if param is not None
+            else super().__getattribute__(name)
         )
 
     @classmethod

--- a/flopy4/param.py
+++ b/flopy4/param.py
@@ -3,6 +3,7 @@ from ast import literal_eval
 from collections import UserDict
 from dataclasses import dataclass, fields
 from io import StringIO
+from pprint import pformat
 from typing import Any, Optional, Tuple
 
 from flopy4.constants import MFReader
@@ -146,6 +147,11 @@ class MFParam(MFParamSpec):
             reader=reader,
             shape=shape,
             default_value=default_value,
+        )
+
+    def __repr__(self):
+        return (
+            super().__repr__() if self.value is None else pformat(self.value)
         )
 
     def __str__(self):

--- a/flopy4/scalar.py
+++ b/flopy4/scalar.py
@@ -50,6 +50,9 @@ class MFScalar(MFParam):
             default_value,
         )
 
+    def __get__(self, obj, type=None):
+        return self if self.value is None else self.value
+
     @property
     def value(self):
         return self._value

--- a/flopy4/utils.py
+++ b/flopy4/utils.py
@@ -22,3 +22,7 @@ def strip(line):
         line = line.split(comment_flag)[0]
     line = line.strip()
     return line.replace(",", " ")
+
+
+class hybridproperty:
+    pass

--- a/test/test_block.py
+++ b/test/test_block.py
@@ -14,7 +14,7 @@ class TestBlock(MFBlock):
     d = MFDouble(description="double")
     s = MFString(description="string", optional=False)
     f = MFFilename(description="filename", optional=False)
-    a = MFArray(description="array", shape=(3))
+    a = MFArray(description="array", shape=(3,))
     r = MFRecord(
         params={
             "rk": MFKeyword(),
@@ -84,20 +84,11 @@ def test_load_write(tmp_path):
     with open(fpth, "r") as f:
         block = TestBlock.load(f)
 
-        # class attribute as param specification
+        # check parameter specification
         assert isinstance(TestBlock.k, MFKeyword)
         assert TestBlock.k.name == "k"
         assert TestBlock.k.block == "options"
         assert TestBlock.k.description == "keyword"
-
-        # instance attribute as shortcut to param valu
-        assert isinstance(block.k, bool)
-        assert block.k
-        assert block.i == 1
-        assert block.d == 1.0
-        assert block.s == "value"
-        assert block.f == fpth
-        assert np.allclose(block.a, np.array([1.0, 2.0, 3.0]))
 
         assert isinstance(TestBlock.r, MFRecord)
         assert TestBlock.r.name == "r"
@@ -106,7 +97,13 @@ def test_load_write(tmp_path):
         assert isinstance(TestBlock.r.params["ri"], MFInteger)
         assert isinstance(TestBlock.r.params["rd"], MFDouble)
 
-        assert isinstance(block.r, dict)
+        # check parameter values (via descriptors)
+        assert block.k
+        assert block.i == 1
+        assert block.d == 1.0
+        assert block.s == "value"
+        assert block.f == fpth
+        assert np.allclose(block.a, np.array([1.0, 2.0, 3.0]))
         assert block.r == {"rd": 2.0, "ri": 2, "rk": True}
 
     # test block write
@@ -165,5 +162,3 @@ def test_load_write_indexed(tmp_path):
         # instance attribute as shortcut to param value
         assert period1.ks == {"first": True}
         assert period2.ks == {"first": True, "frequency": 2}
-
-        assert str(period1)

--- a/test/test_block.py
+++ b/test/test_block.py
@@ -165,3 +165,5 @@ def test_load_write_indexed(tmp_path):
         # instance attribute as shortcut to param value
         assert period1.ks == {"first": True}
         assert period2.ks == {"first": True, "frequency": 2}
+
+        assert str(period1)

--- a/test/test_package.py
+++ b/test/test_package.py
@@ -127,16 +127,15 @@ def test_load_write(tmp_path):
     with open(fpth, "r") as f:
         package = TestPackage.load(f)
 
+        # check block and parameter specifications
         assert len(package.blocks) == 2
         assert len(package.params) == 6
-
-        # class attribute as param specification
         assert isinstance(TestPackage.k, MFKeyword)
         assert TestPackage.k.name == "k"
         assert TestPackage.k.block == "options"
         assert TestPackage.k.description == "keyword"
 
-        # instance attribute as shortcut to param value
+        # check parameter values
         assert isinstance(package.k, bool)
         assert package.k
         assert package.i == 1


### PR DESCRIPTION
* `__str__()` on param, block or package shows what will be written to file
* `__repr__()` on param, block or package shows unambiguous representation
  * value or dict of values for instance
  * spec of dict of specs for class
* attach block attrs to package class
* remove unnecessary params properties