### PR TITLE
seq diagram for attrs/xarray proxy chicanery

### DIFF
--- a/docs/dev/sdd.md
+++ b/docs/dev/sdd.md
@@ -90,9 +90,56 @@ Combining these patterns naively would result in several challenges, involving d
 
 Ultimately, we'd like a mapping between an abstract hierarchy of components and variables, as defined in MF6 definition files, to a Python representation which is self-describing (courtesy of `attrs`) and self-aligning (courtesy of `xarray`).
 
-#### Details
+We can arrange for `attrs` to proxy `xarray`. Each component can own a node in an `xarray.DataTree`, say, in `.data`, which can serve as the component's backing store.
 
-We can arrange for `attrs` to proxy `xarray` via `__getattr__`.
+```mermaid
+sequenceDiagram
+    Note over User: Initialize component
+    User->>Component: __init__()
+    Component->>__dict__: [populate]
+    Note over Component,__dict__: attrs-generated initialization
+    create participant DataTree
+    Component->>DataTree: [create]
+    __dict__->>DataTree: [transfer]
+    Note over Component,DataTree: xarray data tree initialization
+    destroy __dict__
+    Component-x__dict__: 
+    Note over Component,__dict__: __dict__ empty except tree
+    opt bind parent, if exists
+    Component-->>Parent: [bind parent component]
+    DataTree-->>ParentTree: [bind parent tree]
+    DataTree<<-->>ParentTree: [share dimensions]
+    end
+    DataTree->>Component: [return]
+    Component->>User: [return]
+    
+    Note over User: Get variable
+    User->>Component: .var
+    alt is array
+    Component->>DataTree: .data["var"]
+    else is dim
+    Component->>DataTree: .data.dims["var"]
+    else is scalar
+    Component->>DataTree: .data.attrs["var"]
+    end
+    Note over Component,DataTree: override __getattr__, redirect to tree
+    DataTree->>Component: [return value]
+    Component->>User: [return value]
+    
+    Note over User: Set variable
+    User->>Component: .var = ...
+    alt is array
+    Component->>DataTree: .data["var"] = ...
+    DataTree->>DataTree: [check dimensions]
+    else is scalar
+    Component->>DataTree: .data.attrs["var"] = ...
+    end
+    Note over Component,DataTree: use attrs on_setattr hook
+    DataTree->>Component: [return]
+    Component->>User: [return]
+```
+
+We can override `__getattr__` to redirect attribute access to `xarray`.
 
 Likewise, we can use [`on_setattr`](https://www.attrs.org/en/stable/api.html#core) to intercept values sent to the `attrs` attributes and send them to `xarray`.
 


### PR DESCRIPTION
```mermaid
sequenceDiagram
    Note over User: Initialize component
    User->>Component: __init__()
    Component->>__dict__: [populate]
    Note over Component,__dict__: attrs-generated initialization
    create participant DataTree
    Component->>DataTree: [create]
    __dict__->>DataTree: [transfer]
    Note over Component,DataTree: xarray data tree initialization
    destroy __dict__
    Component-x__dict__: 
    Note over Component,__dict__: __dict__ empty except tree
    opt bind parent, if exists
    Component-->>Parent: [bind parent component]
    DataTree-->>ParentTree: [bind parent tree]
    DataTree<<-->>ParentTree: [share dimensions]
    end
    DataTree->>Component: [return]
    Component->>User: [return]
    
    Note over User: Get variable
    User->>Component: .var
    alt is array
    Component->>DataTree: .data["var"]
    else is dim
    Component->>DataTree: .data.dims["var"]
    else is scalar
    Component->>DataTree: .data.attrs["var"]
    end
    Note over Component,DataTree: override __getattr__, redirect to tree
    DataTree->>Component: [return value]
    Component->>User: [return value]
    
    Note over User: Set variable
    User->>Component: .var = ...
    alt is array
    Component->>DataTree: .data["var"] = ...
    DataTree->>DataTree: [check dimensions]
    else is scalar
    Component->>DataTree: .data.attrs["var"] = ...
    end
    Note over Component,DataTree: use attrs on_setattr hook
    DataTree->>Component: [return]
    Component->>User: [return]
```

Does it work? More or less. Is it wise? Time will tell..