### PR TITLE
separate core and mf6 spec

### DIFF
--- a/flopy4/mf6/spec.py
+++ b/flopy4/mf6/spec.py
@@ -4,10 +4,11 @@ These include field decorators and introspection functions.
 """
 
 from attrs import NOTHING, Attribute, fields_dict
-from xattree import array as xattree_array
-from xattree import coord as xattree_coord
-from xattree import dim as xattree_dim
-from xattree import field as xattree_field
+
+from flopy4.spec import array as flopy_array
+from flopy4.spec import coord as flopy_coord
+from flopy4.spec import dim as flopy_dim
+from flopy4.spec import field as flopy_field
 
 
 def field(
@@ -24,7 +25,7 @@ def field(
     if block:
         metadata = metadata or {}
         metadata["block"] = block
-    return xattree_field(
+    return flopy_field(
         default=default,
         validator=validator,
         converter=converter,
@@ -49,7 +50,7 @@ def dim(
     if block:
         metadata = metadata or {}
         metadata["block"] = block
-    return xattree_dim(
+    return flopy_dim(
         scope=scope,
         coord=coord,
         default=default,
@@ -72,7 +73,7 @@ def coord(
     if block:
         metadata = metadata or {}
         metadata["block"] = block
-    return xattree_coord(
+    return flopy_coord(
         scope=scope,
         default=default,
         repr=repr,
@@ -96,7 +97,7 @@ def array(
     if block:
         metadata = metadata or {}
         metadata["block"] = block
-    return xattree_array(
+    return flopy_array(
         cls=cls,
         dims=dims,
         default=default,

--- a/flopy4/spec.py
+++ b/flopy4/spec.py
@@ -1,0 +1,89 @@
+"""Wrap `xattree` and `attrs` specification utilities."""
+
+from attrs import NOTHING
+from xattree import array as xattree_array
+from xattree import coord as xattree_coord
+from xattree import dim as xattree_dim
+from xattree import field as xattree_field
+
+
+def field(
+    default=NOTHING,
+    validator=None,
+    converter=None,
+    repr=True,
+    eq=True,
+    init=True,
+    metadata=None,
+):
+    """Define a field."""
+    return xattree_field(
+        default=default,
+        validator=validator,
+        converter=converter,
+        repr=repr,
+        eq=eq,
+        init=init,
+        metadata=metadata,
+    )
+
+
+def dim(
+    scope=None,
+    coord: bool | str = True,
+    default=NOTHING,
+    repr=True,
+    eq=True,
+    init=True,
+    metadata=None,
+):
+    """Define a dimension field."""
+    return xattree_dim(
+        scope=scope,
+        coord=coord,
+        default=default,
+        repr=repr,
+        eq=eq,
+        init=init,
+        metadata=metadata,
+    )
+
+
+def coord(
+    scope=None,
+    default=NOTHING,
+    repr=True,
+    eq=True,
+    metadata=None,
+):
+    """Define a coordinate field."""
+    return xattree_coord(
+        scope=scope,
+        default=default,
+        repr=repr,
+        eq=eq,
+        metadata=metadata,
+    )
+
+
+def array(
+    cls=None,
+    dims=None,
+    default=NOTHING,
+    validator=None,
+    converter=None,
+    repr=True,
+    eq=None,
+    metadata=None,
+):
+    """Define an array field."""
+    return xattree_array(
+        cls=cls,
+        dims=dims,
+        default=default,
+        validator=validator,
+        converter=converter,
+        repr=repr,
+        eq=eq,
+        metadata=metadata,
+    )


### PR DESCRIPTION
wrap the field decorators at the top level, then wrap those for mf6. this gives us an independent layer, which right now has nothing over and above attrs/xattree, but I can imagine we might want some shared core options in the future. mf6 and other programs can layer custom decorators on top of this where needed.