### PR TITLE
add package class attributes to chd and ims

### DIFF
--- a/flopy4/mf6/gwf/chd.py
+++ b/flopy4/mf6/gwf/chd.py
@@ -13,7 +13,7 @@ from flopy4.mf6.spec import array, field
 
 @xattree
 class Chd(Package):
-    multi: ClassVar[bool] = True
+    multi_package: ClassVar[bool] = True
 
     @define(slots=False)
     class Steps:

--- a/flopy4/mf6/gwf/chd.py
+++ b/flopy4/mf6/gwf/chd.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import ClassVar, Optional
 
 import numpy as np
 from attrs import Converter, define
@@ -13,6 +13,8 @@ from flopy4.mf6.spec import array, field
 
 @xattree
 class Chd(Package):
+    multi: ClassVar[bool] = True
+
     @define(slots=False)
     class Steps:
         all: bool = field()

--- a/flopy4/mf6/ims.py
+++ b/flopy4/mf6/ims.py
@@ -1,6 +1,7 @@
 from pathlib import Path
-from typing import Optional
+from typing import ClassVar, Optional
 
+from modflow_devtools.dfn import Sln
 from xattree import xattree
 
 from flopy4.mf6.solution import Solution
@@ -9,6 +10,8 @@ from flopy4.mf6.spec import field
 
 @xattree
 class Ims(Solution):
+    solution_package: ClassVar[Sln] = Sln(abbr="ims", pattern="*")
+
     print_option: bool = field(block="options", default=False)
     complexity: str = field(block="options", default="simple")
     csv_outer_output_file: Optional[Path] = field(default=None, block="options")

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -2,11 +2,13 @@ import numpy as np
 import pytest
 from flopy.discretization import StructuredGrid
 from flopy.discretization.modeltime import ModelTime
+from modflow_devtools.dfn import Sln
 from xarray import DataTree
 
 from flopy4.mf6.component import COMPONENTS
 from flopy4.mf6.constants import FILL_DNODATA
 from flopy4.mf6.gwf import Chd, Dis, Gwf, Ic, Npf, Oc
+from flopy4.mf6.ims import Ims
 from flopy4.mf6.simulation import Simulation
 from flopy4.mf6.tdis import Tdis
 
@@ -242,3 +244,27 @@ def test_gwf_dfn():
     assert dfn["ref"] is None
     assert dfn["sln"] is None
     assert "save_flows" in set(dfn["options"].keys())
+
+
+def test_chd_dfn():
+    chd = Chd(strict=False)
+    dfn = chd.dfn
+    assert dfn["name"] == "chd"
+    assert not dfn["advanced"]
+    assert dfn["multi"]
+    assert dfn["ref"] is None
+    assert dfn["sln"] is None
+    assert "print_input" in set(dfn["options"].keys())
+    assert "head" in set(dfn["period"].keys())
+
+
+def test_ims_dfn():
+    ims = Ims(strict=False)
+    dfn = ims.dfn
+    assert dfn["name"] == "ims"
+    assert not dfn["advanced"]
+    assert not dfn["multi"]
+    assert dfn["ref"] is None
+    assert dfn["sln"] == Sln(abbr="ims", pattern="*")
+    assert "complexity" in set(dfn["options"].keys())
+    assert "inner_maximum" in set(dfn["linear"].keys())


### PR DESCRIPTION
Mark packages as solution packages, multipackages. Same idea would work for advanced packages and subpackages too. These attributes are discovered/reflected by `Component.dfn` as added in #139.