### PR TITLE
draft roadmap

### DIFF
--- a/docs/dev/map.md
+++ b/docs/dev/map.md
@@ -25,7 +25,7 @@ Adopt features from e.g. `imod-python`.
 Incorporate feedback from alpha testing.
 Beta testers include alpha testers and additional volunteers from USGS and Deltares.
 Release via `pip install` from github URL of our development sandbox.
-Tentative timeframe: October.
+Tentative timeframe: by end of year?
 
 - [ ] reimplement object model (maintainability over magic)
 - [ ] structured xarray index for topology/geometry-aware selections
@@ -35,9 +35,6 @@ Tentative timeframe: October.
 - [ ] IO optimization (tuning, laziness/concurrency, etc)
 - [ ] comprehensive logging and error handling
 - [ ] validation framework, model checks
-- [ ] command line interface
-- [ ] cell inspector
-- [ ] unit-awareness
 
 ## Phase 3: Rollout
 
@@ -45,7 +42,6 @@ Integrate the product with the existing repository.
 Evaluate feature-parity and fill any remaining gaps.
 Release via standard channels (PyPI, Conda).
 Dial 3.x down to maintenance mode.
-Tentative timeframe: January 2026
 
 - [ ] implement 3.x adapters, compare tests/examples
 - [ ] finalize 3.x maintenance plan and 4.x release plan

--- a/docs/dev/map.md
+++ b/docs/dev/map.md
@@ -1,0 +1,49 @@
+# FloPy 4 development roadmap
+
+## Phase 1: Minimum Viable Product
+
+Read/write input files, run simulations, get/set data.
+Initial deliverable for alpha testing (USGS, Deltares).
+Alpha testers include Joeri, Huite, and the core MF6 team.
+Release via `pip install ` from github URL of our development sandbox.
+Tentative timeframe: July.
+
+- [x] DFN spec to TOML
+- [x] xarray/attrs backend
+- [x] unified IO framework
+- [ ] MF6 input file parser
+- [ ] MF6 input file writer
+- [ ] code generation from spec
+- [ ] minimal docs (quickstart, etc)
+
+## Phase 2: Minimum Marketable Product
+
+Achieve rough feature-parity with 3.x.
+Adopt features from e.g. `imod-python`.
+Incorporate feedback from alpha testing.
+Beta testers include alpha testers and additional volunteers from USGS and Deltares.
+Release via `pip install` from github URL of our development sandbox.
+Tentative timeframe: October.
+
+- [ ] structured xarray index for topology/geometry-aware selections
+- [ ] xarray accessors for cross-cutting concerns (plot, export)
+- [ ] xugrid integration for UGRID-compliance (DIS/DISV grids)
+- [ ] more extensive docs (converted from old flopy examples)
+- [ ] IO optimization (tuning, laziness/concurrency, etc)
+- [ ] comprehensive logging and error handling
+- [ ] validation framework, model checks
+- [ ] command line interface
+- [ ] cell inspector
+- [ ] unit-awareness
+
+## Phase 3: Rollout
+
+Integrate the product with the existing repository.
+Evaluate feature-parity and fill any remaining gaps.
+Release via standard channels (PyPI, Conda).
+Dial 3.x down to maintenance mode.
+Tentative timeframe: January 2026
+
+- [ ] implement 3.x adapters, compare tests/examples
+- [ ] finalize 3.x maintenance plan and 4.x release plan
+- [ ] finalize MF6 compatibility policy and codegen tooling

--- a/docs/dev/map.md
+++ b/docs/dev/map.md
@@ -9,7 +9,7 @@ Release via `pip install ` from github URL of our development sandbox.
 Tentative timeframe: July.
 
 - [x] DFN spec to TOML
-- [x] xarray/attrs backend
+- [x] draft object model
 - [x] unified IO framework
 - [ ] MF6 input file parser
 - [ ] MF6 input file writer
@@ -18,6 +18,7 @@ Tentative timeframe: July.
 
 ## Phase 2: Minimum Marketable Product
 
+Refactor to make production-ready.
 Achieve rough feature-parity with 3.x.
 Adopt features from e.g. `imod-python`.
 Incorporate feedback from alpha testing.
@@ -25,6 +26,7 @@ Beta testers include alpha testers and additional volunteers from USGS and Delta
 Release via `pip install` from github URL of our development sandbox.
 Tentative timeframe: October.
 
+- [ ] reimplement object model (maintainability over magic)
 - [ ] structured xarray index for topology/geometry-aware selections
 - [ ] xarray accessors for cross-cutting concerns (plot, export)
 - [ ] xugrid integration for UGRID-compliance (DIS/DISV grids)

--- a/docs/dev/map.md
+++ b/docs/dev/map.md
@@ -2,6 +2,7 @@
 
 ## Phase 1: Minimum Viable Product
 
+Core functionality. Shortcuts are OK.
 Read/write input files, run simulations, get/set data.
 Initial deliverable for alpha testing (USGS, Deltares).
 Alpha testers include Joeri, Huite, and the core MF6 team.


### PR DESCRIPTION
I don't know how detailed we want the line items to be, so I just included everything I saw or remembered a discussion for. I probably missed some.

For what it's worth, I still think `xattree` is a horrible hack, and way too magical to rely on. It's fine for the MVP I guess. I've got some ideas how to improve on the general idea of marrying `attrs` and `xarray`. I added an item for this to phase 2.

The timeline is optimistic. Pessimistic version, maybe MVP August, MMP end of year, and we play the final rollout by ear?