### PR TITLE
test(io): ascii write cleanup

### DIFF
--- a/flopy4/mf6/codec/writer/templates/macros.jinja
+++ b/flopy4/mf6/codec/writer/templates/macros.jinja
@@ -22,8 +22,8 @@
 
 {% macro keystring(name, value) %}
 {% for option in (value|data2keystring) -%}
-{{ record("", option) }}
-{% endfor %}
+{{ record("", option) }}{% if not loop.last %}{{ "\n" }}{% endif %}
+{%- endfor %}
 {% endmacro %}
 
 {% macro record(name, value) %}
@@ -37,26 +37,26 @@
 {% endmacro %}
 
 {% macro array(name, value, how="internal") %}
-{{ name.upper() }}{% if "layered" in how %} LAYERED{% endif %}
+{{ inset ~ name.upper() }}{% if "layered" in how %} LAYERED{% endif %}
 
 {% if how == "constant" %}
-CONSTANT {{ value.item() }}
+    CONSTANT {{ value.item() }}
 {% elif how == "layered constant" %}
 {% for layer in value -%}
-CONSTANT {{ layer.item() }}
+    CONSTANT {{ layer.item() }}
 {%- endfor %}
 {% elif how == "internal" %}
-INTERNAL
+    INTERNAL
 {% for chunk in value|array_chunks -%}
-{{ chunk|array2string }}
+{{ (2 * inset) ~ chunk|array2string }}
 {%- endfor %}
 {% elif how == "external" %}
-OPEN/CLOSE {{ value }}
+    OPEN/CLOSE {{ value }}
 {% endif %}
 {% endmacro %}
 
 {% macro list(name, value) %}
 {% for row in (value|data2list) %}
-{{ inset ~ row|join(" ") }}
-{% endfor %}
+{{ inset ~ row|join(" ") }}{% if not loop.last %}{{ "\n" }}{% endif %}
+{%- endfor %}
 {% endmacro %}

--- a/flopy4/mf6/gwf/oc.py
+++ b/flopy4/mf6/gwf/oc.py
@@ -16,6 +16,7 @@ from flopy4.utils import to_path
 class Oc(Package):
     @define(slots=False)
     class Format:
+        fmt_kw: str = field(default="print_format")
         columns: int = field(default=10)
         width: int = field(default=11)
         digits: int = field(default=4)
@@ -49,7 +50,8 @@ class Oc(Package):
         converter=to_path,
         default=None,
     )
-    format: Optional[Format] = field(block="options", default=None, init=False)
+    # TODO: needs coverter and then rename?
+    head: Optional[Format] = field(block="options", default=None)
     save_head: Optional[NDArray[np.object_]] = array(
         object,
         block="period",

--- a/flopy4/mf6/ims.py
+++ b/flopy4/mf6/ims.py
@@ -13,7 +13,6 @@ class Ims(Solution):
     solution_package: ClassVar[Sln] = Sln(abbr="ims", pattern="*")
     slntype: ClassVar[str] = "ims"
 
-    mxiter: Optional[int] = field(default=1)
     print_option: Optional[str] = field(block="options", default=None)
     complexity: str = field(block="options", default="simple")
     csv_outer_output_file: Optional[Path] = field(default=None, block="options")

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -321,7 +321,7 @@ def test_gwf_chd01(function_tmpdir):
         parent=gwf,
         budget_file=f"{gwf_name}.cbc",
         head_file=f"{gwf_name}.hds",
-        # COLUMNS  10  WIDTH  15  DIGITS  6  GENERAL
+        head="PRINT_FORMAT COLUMNS  10  WIDTH  15  DIGITS  6  GENERAL",
         save_head=["last"],
         # save_head={0: "last"},
         save_budget=["last"],


### PR DESCRIPTION
Follow up to #186 , adds first pass support for OC head print formats and improved formatting of ascii files.