### PR TITLE
oc parser/transformer working?

### DIFF
--- a/flopy4/mf6/codec/reader/grammar/filters.py
+++ b/flopy4/mf6/codec/reader/grammar/filters.py
@@ -18,14 +18,21 @@ def field_type(field: FieldV2) -> str:
 
 
 def record_child_type(field: FieldV2) -> str:
-    """Get the grammar type for a field within a record context."""
+    """
+    Get the grammar type for a field within a record context.
+
+    In records, string fields should use 'word' instead of 'string'
+    to avoid consuming the rest of the line (since string matches token+ NEWLINE).
+    """
     match field.type:
-        case t if t in ["string", "double", "integer"]:
+        case "string":
+            return "word"  # Use word for strings in records to match single tokens
+        case t if t in ["double", "integer"]:
             return t
         case "keyword":
             return ""
         case "union":
-            return ""  # keystrings generate their own union rules
+            return ""  # unions generate their own union rules
         case _:
             return field.type
 

--- a/flopy4/mf6/codec/reader/grammar/generated/chf-cdb.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/chf-cdb.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,6 +28,6 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-obs_filerecord: "filein"i "obs6"i string
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/chf-chd.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/chf-chd.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/chf-cxs.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/chf-cxs.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -26,5 +27,5 @@ crosssectiondata_fields: (crosssectiondata)*
 print_input: "print_input"i 
 nsections: "nsections"i integer
 npoints: "npoints"i integer
-packagedata: "packagedata"i recarray
-crosssectiondata: "crosssectiondata"i recarray
+packagedata: "packagedata"i list
+crosssectiondata: "crosssectiondata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/chf-dfw.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/chf-dfw.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -25,7 +26,7 @@ time_conversion: "time_conversion"i double
 save_flows: "save_flows"i 
 print_flows: "print_flows"i 
 save_velocity: "save_velocity"i 
-obs_filerecord: "obs6"i "filein"i string
+obs_filerecord: "obs6"i "filein"i word
 export_array_ascii: "export_array_ascii"i 
 dev_swr_conductance: "dev_swr_conductance"i 
 manningsn: "manningsn"i array

--- a/flopy4/mf6/codec/reader/grammar/generated/chf-disv1d.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/chf-disv1d.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,7 +28,7 @@ vertices_fields: (vertices)*
 cell1d_fields: (cell1d)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
@@ -38,5 +39,5 @@ nvert: "nvert"i integer
 width: "width"i array
 bottom: "bottom"i array
 idomain: "idomain"i array
-vertices: "vertices"i recarray
-cell1d: "cell1d"i recarray
+vertices: "vertices"i list
+cell1d: "cell1d"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/chf-evp.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/chf-evp.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/chf-flw.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/chf-flw.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/chf-ic.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/chf-ic.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/chf-nam.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/chf-nam.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -24,4 +25,4 @@ print_input: "print_input"i
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
 newtonoptions: "newton"i "under_relaxation"i
-packages: "packages"i recarray
+packages: "packages"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/chf-oc.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/chf-oc.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,10 +21,17 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | qoutflow_filerecord | stage_filerecord | qoutflowprintrecord)*
 period_fields: (saverecord | printrecord)*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-qoutflow_filerecord: "fileout"i "qoutflow"i string
-stage_filerecord: "fileout"i "stage"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+qoutflow_filerecord: "qoutflow"i "fileout"i word
+stage_filerecord: "stage"i "fileout"i word
 qoutflowprintrecord: "qoutflow"i "print_format"i
-saverecord: "save"i string keystring
-printrecord: "print"i string keystring
+saverecord: "save"i word ocsetting
+printrecord: "print"i word ocsetting
+ocsetting: ocsetting_all | ocsetting_first | ocsetting_last | ocsetting_frequency | ocsetting_steps
+ocsetting_all: "all"i
+ocsetting_first: "first"i
+ocsetting_last: "last"i
+ocsetting_frequency: "frequency"i integer
+ocsetting_steps: "steps"i integer+
+

--- a/flopy4/mf6/codec/reader/grammar/generated/chf-pcp.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/chf-pcp.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/chf-sto.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/chf-sto.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/chf-zdg.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/chf-zdg.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,7 +28,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/exg-chfgwf.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/exg-chfgwf.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -24,6 +25,6 @@ exchangedata_fields: (exchangedata)*
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 fixed_conductance: "fixed_conductance"i 
-obs_filerecord: "obs6"i "filein"i string
+obs_filerecord: "obs6"i "filein"i word
 nexg: "nexg"i integer
-exchangedata: "exchangedata"i recarray
+exchangedata: "exchangedata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/exg-gwegwe.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/exg-gwegwe.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -31,8 +32,8 @@ save_flows: "save_flows"i
 adv_scheme: "adv_scheme"i string
 cnd_xt3d_off: "cnd_xt3d_off"i 
 cnd_xt3d_rhs: "cnd_xt3d_rhs"i 
-mve_filerecord: "filein"i "mve6"i string
-obs_filerecord: "filein"i "obs6"i string
+mve_filerecord: "mve6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 dev_interfacemodel_on: "dev_interfacemodel_on"i 
 nexg: "nexg"i integer
-exchangedata: "exchangedata"i recarray
+exchangedata: "exchangedata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/exg-gwfgwe.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/exg-gwfgwe.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/exg-gwfgwf.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/exg-gwfgwf.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -30,9 +31,9 @@ cell_averaging: "cell_averaging"i string
 cvoptions: "variablecv"i "dewatered"i
 newton: "newton"i 
 xt3d: "xt3d"i 
-gnc_filerecord: "filein"i "gnc6"i string
-mvr_filerecord: "filein"i "mvr6"i string
-obs_filerecord: "filein"i "obs6"i string
+gnc_filerecord: "gnc6"i "filein"i word
+mvr_filerecord: "mvr6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 dev_interfacemodel_on: "dev_interfacemodel_on"i 
 nexg: "nexg"i integer
-exchangedata: "exchangedata"i recarray
+exchangedata: "exchangedata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/exg-gwfgwt.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/exg-gwfgwt.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/exg-gwfprt.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/exg-gwfprt.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/exg-gwtgwt.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/exg-gwtgwt.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -31,8 +32,8 @@ save_flows: "save_flows"i
 adv_scheme: "adv_scheme"i string
 dsp_xt3d_off: "dsp_xt3d_off"i 
 dsp_xt3d_rhs: "dsp_xt3d_rhs"i 
-mvt_filerecord: "filein"i "mvt6"i string
-obs_filerecord: "filein"i "obs6"i string
+mvt_filerecord: "mvt6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 dev_interfacemodel_on: "dev_interfacemodel_on"i 
 nexg: "nexg"i integer
-exchangedata: "exchangedata"i recarray
+exchangedata: "exchangedata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/exg-olfgwf.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/exg-olfgwf.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -24,6 +25,6 @@ exchangedata_fields: (exchangedata)*
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 fixed_conductance: "fixed_conductance"i 
-obs_filerecord: "obs6"i "filein"i string
+obs_filerecord: "obs6"i "filein"i word
 nexg: "nexg"i integer
-exchangedata: "exchangedata"i recarray
+exchangedata: "exchangedata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-adv.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-adv.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-cnd.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-cnd.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-ctp.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-ctp.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-dis.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-dis.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,14 +24,14 @@ dimensions_fields: (nlay | nrow | ncol)*
 griddata_fields: (delr | delc | top | botm | idomain)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
 export_array_ascii: "export_array_ascii"i 
 export_array_netcdf: "export_array_netcdf"i 
 crs: "crs"i array
-ncf_filerecord: "ncf6"i "filein"i string
+ncf_filerecord: "ncf6"i "filein"i word
 nlay: "nlay"i integer
 nrow: "nrow"i integer
 ncol: "ncol"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-disu.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-disu.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -29,7 +30,7 @@ vertices_fields: (vertices)*
 cell2d_fields: (cell2d)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
@@ -49,5 +50,5 @@ ihc: "ihc"i array
 cl12: "cl12"i array
 hwva: "hwva"i array
 angldegx: "angldegx"i array
-vertices: "vertices"i recarray
-cell2d: "cell2d"i recarray
+vertices: "vertices"i list
+cell2d: "cell2d"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-disv.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-disv.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,19 +28,19 @@ vertices_fields: (vertices)*
 cell2d_fields: (cell2d)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
 export_array_ascii: "export_array_ascii"i 
 export_array_netcdf: "export_array_netcdf"i 
 crs: "crs"i array
-ncf_filerecord: "ncf6"i "filein"i string
+ncf_filerecord: "ncf6"i "filein"i word
 nlay: "nlay"i integer
 ncpl: "ncpl"i integer
 nvert: "nvert"i integer
 top: "top"i array
 botm: "botm"i array
 idomain: "idomain"i array
-vertices: "vertices"i recarray
-cell2d: "cell2d"i recarray
+vertices: "vertices"i list
+cell2d: "cell2d"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-esl.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-esl.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-est.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-est.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-fmi.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-fmi.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -21,4 +22,4 @@ options_fields: (save_flows | flow_imbalance_correction)*
 packagedata_fields: (packagedata)*
 save_flows: "save_flows"i 
 flow_imbalance_correction: "flow_imbalance_correction"i 
-packagedata: "packagedata"i recarray
+packagedata: "packagedata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-ic.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-ic.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-lke.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-lke.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,7 +21,7 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | ts_filerecord | obs_filerecord)*
 period_fields: ()*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-mve.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-mve.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,5 +21,5 @@ options_fields: (print_input | print_flows | save_flows | budget_filerecord | bu
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-mwe.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-mwe.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,7 +21,7 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | ts_filerecord | obs_filerecord)*
 period_fields: ()*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-nam.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-nam.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -24,7 +25,7 @@ print_input: "print_input"i
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
 dependent_variable_scaling: "dependent_variable_scaling"i 
-nc_mesh2d_filerecord: "netcdf_mesh2d"i "fileout"i string
-nc_structured_filerecord: "netcdf_structured"i "fileout"i string
-nc_filerecord: "netcdf"i "filein"i string
-packages: "packages"i recarray
+nc_mesh2d_filerecord: "netcdf_mesh2d"i "fileout"i word
+nc_structured_filerecord: "netcdf_structured"i "fileout"i word
+nc_filerecord: "netcdf"i "filein"i word
+packages: "packages"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-oc.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-oc.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,9 +21,16 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | temperature_filerecord | temperatureprintrecord)*
 period_fields: (saverecord | printrecord)*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-temperature_filerecord: "fileout"i "temperature"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+temperature_filerecord: "temperature"i "fileout"i word
 temperatureprintrecord: "temperature"i "print_format"i
-saverecord: "save"i string keystring
-printrecord: "print"i string keystring
+saverecord: "save"i word ocsetting
+printrecord: "print"i word ocsetting
+ocsetting: ocsetting_all | ocsetting_first | ocsetting_last | ocsetting_frequency | ocsetting_steps
+ocsetting_all: "all"i
+ocsetting_first: "first"i
+ocsetting_last: "last"i
+ocsetting_frequency: "frequency"i integer
+ocsetting_steps: "steps"i integer+
+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-sfe.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-sfe.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,7 +21,7 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | ts_filerecord | obs_filerecord)*
 period_fields: ()*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-ssm.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-ssm.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -21,4 +22,4 @@ options_fields: (print_flows | save_flows)*
 fileinput_fields: (fileinput)*
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-fileinput: "fileinput"i recarray
+fileinput: "fileinput"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwe-uze.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwe-uze.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,7 +21,7 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | ts_filerecord | obs_filerecord)*
 period_fields: ()*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-api.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-api.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,6 +24,6 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-obs_filerecord: "obs6"i "filein"i string
+obs_filerecord: "obs6"i "filein"i word
 mover: "mover"i 
 maxbound: "maxbound"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-buy.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-buy.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,7 +24,7 @@ dimensions_fields: (nrhospecies)*
 packagedata_fields: (packagedata)*
 hhformulation_rhs: "hhformulation_rhs"i 
 denseref: "denseref"i double
-density_filerecord: "density"i "fileout"i string
+density_filerecord: "density"i "fileout"i word
 dev_efh_formulation: "dev_efh_formulation"i 
 nrhospecies: "nrhospecies"i integer
-packagedata: "packagedata"i recarray
+packagedata: "packagedata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-chd.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-chd.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,8 +29,8 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 dev_no_newton: "dev_no_newton"i 
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-csub.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-csub.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -39,17 +40,17 @@ specified_initial_interbed_state: "specified_initial_interbed_state"i
 specified_initial_preconsolidation_stress: "specified_initial_preconsolidation_stress"i 
 specified_initial_delay_head: "specified_initial_delay_head"i 
 effective_stress_lag: "effective_stress_lag"i 
-strainib_filerecord: "strain_csv_interbed"i "fileout"i string
-straincg_filerecord: "fileout"i "strain_csv_coarse"i string
-compaction_filerecord: "fileout"i "compaction"i string
-compaction_elastic_filerecord: "fileout"i "compaction_elastic"i string
-compaction_inelastic_filerecord: "fileout"i "compaction_inelastic"i string
-compaction_interbed_filerecord: "fileout"i "compaction_interbed"i string
-compaction_coarse_filerecord: "fileout"i "compaction_coarse"i string
-zdisplacement_filerecord: "fileout"i "zdisplacement"i string
-package_convergence_filerecord: "fileout"i "package_convergence"i string
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+strainib_filerecord: "strain_csv_interbed"i "fileout"i word
+straincg_filerecord: "strain_csv_coarse"i "fileout"i word
+compaction_filerecord: "compaction"i "fileout"i word
+compaction_elastic_filerecord: "compaction_elastic"i "fileout"i word
+compaction_inelastic_filerecord: "compaction_inelastic"i "fileout"i word
+compaction_interbed_filerecord: "compaction_interbed"i "fileout"i word
+compaction_coarse_filerecord: "compaction_coarse"i "fileout"i word
+zdisplacement_filerecord: "zdisplacement"i "fileout"i word
+package_convergence_filerecord: "package_convergence"i "fileout"i word
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 ninterbeds: "ninterbeds"i integer
 maxsig0: "maxsig0"i integer
 cg_ske_cr: "cg_ske_cr"i array

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-dis.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-dis.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,14 +24,14 @@ dimensions_fields: (nlay | nrow | ncol)*
 griddata_fields: (delr | delc | top | botm | idomain)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
 export_array_ascii: "export_array_ascii"i 
 export_array_netcdf: "export_array_netcdf"i 
 crs: "crs"i array
-ncf_filerecord: "ncf6"i "filein"i string
+ncf_filerecord: "ncf6"i "filein"i word
 nlay: "nlay"i integer
 nrow: "nrow"i integer
 ncol: "ncol"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-disu.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-disu.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -29,7 +30,7 @@ vertices_fields: (vertices)*
 cell2d_fields: (cell2d)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
@@ -49,5 +50,5 @@ ihc: "ihc"i array
 cl12: "cl12"i array
 hwva: "hwva"i array
 angldegx: "angldegx"i array
-vertices: "vertices"i recarray
-cell2d: "cell2d"i recarray
+vertices: "vertices"i list
+cell2d: "cell2d"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-disv.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-disv.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,19 +28,19 @@ vertices_fields: (vertices)*
 cell2d_fields: (cell2d)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
 export_array_ascii: "export_array_ascii"i 
 export_array_netcdf: "export_array_netcdf"i 
 crs: "crs"i array
-ncf_filerecord: "ncf6"i "filein"i string
+ncf_filerecord: "ncf6"i "filein"i word
 nlay: "nlay"i integer
 ncpl: "ncpl"i integer
 nvert: "nvert"i integer
 top: "top"i array
 botm: "botm"i array
 idomain: "idomain"i array
-vertices: "vertices"i recarray
-cell2d: "cell2d"i recarray
+vertices: "vertices"i list
+cell2d: "cell2d"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-drn.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-drn.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -29,8 +30,8 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 mover: "mover"i 
 dev_cubic_scaling: "dev_cubic_scaling"i 
 maxbound: "maxbound"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-drng.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-drng.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -29,7 +30,7 @@ auxdepthname: "auxdepthname"i string
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-obs_filerecord: "obs6"i "filein"i string
+obs_filerecord: "obs6"i "filein"i word
 mover: "mover"i 
 export_array_netcdf: "export_array_netcdf"i 
 dev_cubic_scaling: "dev_cubic_scaling"i 

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-evt.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-evt.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -29,8 +30,8 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 surf_rate_specified: "surf_rate_specified"i 
 maxbound: "maxbound"i integer
 nseg: "nseg"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-evta.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-evta.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,7 +28,7 @@ auxmultname: "auxmultname"i string
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-tas_filerecord: "tas6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+tas_filerecord: "tas6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 export_array_netcdf: "export_array_netcdf"i 
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-ghb.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-ghb.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,8 +29,8 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 mover: "mover"i 
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-ghbg.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-ghbg.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ auxmultname: "auxmultname"i string
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-obs_filerecord: "obs6"i "filein"i string
+obs_filerecord: "obs6"i "filein"i word
 mover: "mover"i 
 export_array_netcdf: "export_array_netcdf"i 
 maxbound: "maxbound"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-gnc.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-gnc.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -26,4 +27,4 @@ print_flows: "print_flows"i
 explicit: "explicit"i 
 numgnc: "numgnc"i integer
 numalphaj: "numalphaj"i integer
-gncdata: "gncdata"i recarray
+gncdata: "gncdata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-hfb.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-hfb.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-ic.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-ic.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-lak.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-lak.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ period_fields: ()*
 tables_fields: (tables)*
 connectiondata_fields: (connectiondata)*
 outlets_fields: (outlets)*
-obs_filerecord: "obs6"i string
+obs_filerecord: "obs6"i word
 mover: "mover"i 
 surfdep: "surfdep"i double
 maximum_iterations: "maximum_iterations"i integer
@@ -38,6 +39,6 @@ length_conversion: "length_conversion"i double
 nlakes: "nlakes"i integer
 noutlets: "noutlets"i integer
 ntables: "ntables"i integer
-tables: "tables"i recarray
-connectiondata: "connectiondata"i recarray
-outlets: "outlets"i recarray
+tables: "tables"i list
+connectiondata: "connectiondata"i list
+outlets: "outlets"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-maw.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-maw.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -29,17 +30,17 @@ print_input: "print_input"i
 print_head: "print_head"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-head_filerecord: "head"i string "fileout"i
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
+head_filerecord: "head"i "fileout"i word
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
 no_well_storage: "no_well_storage"i 
 flow_correction: "flow_correction"i 
 flowing_wells: "flowing_wells"i 
 shutdown_theta: "shutdown_theta"i double
 shutdown_kappa: "shutdown_kappa"i double
-mfrcsv_filerecord: "fileout"i "maw_flow_reduce_csv"i string
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+mfrcsv_filerecord: "maw_flow_reduce_csv"i "fileout"i word
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 mover: "mover"i 
 nmawwells: "nmawwells"i integer
-connectiondata: "connectiondata"i recarray
+connectiondata: "connectiondata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-mvr.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-mvr.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,9 +28,9 @@ packages_fields: (packages)*
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 modelnames: "modelnames"i 
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
 maxmvr: "maxmvr"i integer
 maxpackages: "maxpackages"i integer
-packages: "packages"i recarray
+packages: "packages"i list
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-nam.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-nam.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -24,7 +25,7 @@ print_input: "print_input"i
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
 newtonoptions: "newton"i "under_relaxation"i
-nc_mesh2d_filerecord: "netcdf_mesh2d"i "fileout"i string
-nc_structured_filerecord: "netcdf_structured"i "fileout"i string
-nc_filerecord: "netcdf"i "filein"i string
-packages: "packages"i recarray
+nc_mesh2d_filerecord: "netcdf_mesh2d"i "fileout"i word
+nc_structured_filerecord: "netcdf_structured"i "fileout"i word
+nc_filerecord: "netcdf"i "filein"i word
+packages: "packages"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-npf.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-npf.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -32,7 +33,7 @@ save_specific_discharge: "save_specific_discharge"i
 save_saturation: "save_saturation"i 
 k22overk: "k22overk"i 
 k33overk: "k33overk"i 
-tvk_filerecord: "tvk6"i "filein"i string
+tvk_filerecord: "tvk6"i "filein"i word
 export_array_ascii: "export_array_ascii"i 
 export_array_netcdf: "export_array_netcdf"i 
 dev_no_newton: "dev_no_newton"i 

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-oc.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-oc.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,9 +21,16 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | head_filerecord | headprintrecord)*
 period_fields: (saverecord | printrecord)*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-head_filerecord: "fileout"i "head"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+head_filerecord: "head"i "fileout"i word
 headprintrecord: "head"i "print_format"i
-saverecord: "save"i string keystring
-printrecord: "print"i string keystring
+saverecord: "save"i word ocsetting
+printrecord: "print"i word ocsetting
+ocsetting: ocsetting_all | ocsetting_first | ocsetting_last | ocsetting_frequency | ocsetting_steps
+ocsetting_all: "all"i
+ocsetting_first: "first"i
+ocsetting_last: "last"i
+ocsetting_frequency: "frequency"i integer
+ocsetting_steps: "steps"i integer+
+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-rch.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-rch.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -29,7 +30,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-rcha.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-rcha.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,7 +28,7 @@ auxmultname: "auxmultname"i string
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-tas_filerecord: "tas6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+tas_filerecord: "tas6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 export_array_netcdf: "export_array_netcdf"i 
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-riv.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-riv.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,8 +29,8 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 mover: "mover"i 
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-rivg.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-rivg.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ auxmultname: "auxmultname"i string
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-obs_filerecord: "obs6"i "filein"i string
+obs_filerecord: "obs6"i "filein"i word
 mover: "mover"i 
 export_array_netcdf: "export_array_netcdf"i 
 maxbound: "maxbound"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-sfr.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-sfr.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ period_fields: ()*
 crosssections_fields: (crosssections)*
 connectiondata_fields: (connectiondata)*
 initialstages_fields: (initialstages)*
-obs_filerecord: "obs6"i string
+obs_filerecord: "obs6"i word
 mover: "mover"i 
 maximum_picard_iterations: "maximum_picard_iterations"i integer
 maximum_iterations: "maximum_iterations"i integer
@@ -38,6 +39,6 @@ length_conversion: "length_conversion"i double
 time_conversion: "time_conversion"i double
 dev_storage_weight: "dev_storage_weight"i double
 nreaches: "nreaches"i integer
-crosssections: "crosssections"i recarray
-connectiondata: "connectiondata"i recarray
-initialstages: "initialstages"i recarray
+crosssections: "crosssections"i list
+connectiondata: "connectiondata"i list
+initialstages: "initialstages"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-sto.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-sto.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -25,7 +26,7 @@ period_fields: (steady-state | transient)*
 save_flows: "save_flows"i 
 storagecoefficient: "storagecoefficient"i 
 ss_confined_only: "ss_confined_only"i 
-tvs_filerecord: "tvs6"i "filein"i string
+tvs_filerecord: "tvs6"i "filein"i word
 export_array_ascii: "export_array_ascii"i 
 export_array_netcdf: "export_array_netcdf"i 
 dev_original_specific_storage: "dev_original_specific_storage"i 

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-uzf.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-uzf.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,12 +29,12 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-wc_filerecord: "water_content"i string "fileout"i
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-package_convergence_filerecord: "fileout"i "package_convergence"i string
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+wc_filerecord: "water_content"i "fileout"i word
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+package_convergence_filerecord: "package_convergence"i "fileout"i word
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 mover: "mover"i 
 simulate_et: "simulate_et"i 
 linear_gwet: "linear_gwet"i 

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-vsc.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-vsc.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,6 +28,6 @@ thermal_formulation: "thermal_formulation"i string
 thermal_a2: "thermal_a2"i double
 thermal_a3: "thermal_a3"i double
 thermal_a4: "thermal_a4"i double
-viscosity_filerecord: "viscosity"i "fileout"i string
+viscosity_filerecord: "viscosity"i "fileout"i word
 nviscspecies: "nviscspecies"i integer
-packagedata: "packagedata"i recarray
+packagedata: "packagedata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-wel.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-wel.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -29,9 +30,9 @@ print_input: "print_input"i
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
 auto_flow_reduce: "auto_flow_reduce"i double
-afrcsv_filerecord: "auto_flow_reduce_csv"i "fileout"i string
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+afrcsv_filerecord: "auto_flow_reduce_csv"i "fileout"i word
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 mover: "mover"i 
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwf-welg.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwf-welg.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -29,8 +30,8 @@ print_input: "print_input"i
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
 auto_flow_reduce: "auto_flow_reduce"i double
-afrcsv_filerecord: "auto_flow_reduce_csv"i "fileout"i string
-obs_filerecord: "filein"i "obs6"i string
+afrcsv_filerecord: "auto_flow_reduce_csv"i "fileout"i word
+obs_filerecord: "obs6"i "filein"i word
 mover: "mover"i 
 export_array_netcdf: "export_array_netcdf"i 
 maxbound: "maxbound"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-adv.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-adv.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-api.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-api.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,6 +24,6 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-obs_filerecord: "obs6"i "filein"i string
+obs_filerecord: "obs6"i "filein"i word
 mover: "mover"i 
 maxbound: "maxbound"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-cnc.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-cnc.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-dis.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-dis.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,14 +24,14 @@ dimensions_fields: (nlay | nrow | ncol)*
 griddata_fields: (delr | delc | top | botm | idomain)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
 export_array_ascii: "export_array_ascii"i 
 export_array_netcdf: "export_array_netcdf"i 
 crs: "crs"i array
-ncf_filerecord: "ncf6"i "filein"i string
+ncf_filerecord: "ncf6"i "filein"i word
 nlay: "nlay"i integer
 nrow: "nrow"i integer
 ncol: "ncol"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-disu.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-disu.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -29,7 +30,7 @@ vertices_fields: (vertices)*
 cell2d_fields: (cell2d)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
@@ -49,5 +50,5 @@ ihc: "ihc"i array
 cl12: "cl12"i array
 hwva: "hwva"i array
 angldegx: "angldegx"i array
-vertices: "vertices"i recarray
-cell2d: "cell2d"i recarray
+vertices: "vertices"i list
+cell2d: "cell2d"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-disv.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-disv.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,19 +28,19 @@ vertices_fields: (vertices)*
 cell2d_fields: (cell2d)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
 export_array_ascii: "export_array_ascii"i 
 export_array_netcdf: "export_array_netcdf"i 
 crs: "crs"i array
-ncf_filerecord: "ncf6"i "filein"i string
+ncf_filerecord: "ncf6"i "filein"i word
 nlay: "nlay"i integer
 ncpl: "ncpl"i integer
 nvert: "nvert"i integer
 top: "top"i array
 botm: "botm"i array
 idomain: "idomain"i array
-vertices: "vertices"i recarray
-cell2d: "cell2d"i recarray
+vertices: "vertices"i list
+cell2d: "cell2d"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-dsp.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-dsp.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-fmi.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-fmi.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -21,4 +22,4 @@ options_fields: (save_flows | flow_imbalance_correction)*
 packagedata_fields: (packagedata)*
 save_flows: "save_flows"i 
 flow_imbalance_correction: "flow_imbalance_correction"i 
-packagedata: "packagedata"i recarray
+packagedata: "packagedata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-ic.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-ic.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-ist.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-ist.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,7 +21,7 @@ griddata_block: "begin"i "griddata"i griddata_fields "end"i "griddata"i
 options_fields: (cimprintrecord | sorbate_filerecord | export_array_ascii | export_array_netcdf)*
 griddata_fields: (porosity | volfrac | zetaim | decay | decay_sorbed | bulk_density | distcoef | sp2)*
 cimprintrecord: "print_format"i
-sorbate_filerecord: "sorbate"i string
+sorbate_filerecord: "sorbate"i word
 export_array_ascii: "export_array_ascii"i 
 export_array_netcdf: "export_array_netcdf"i 
 porosity: "porosity"i array

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-lkt.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-lkt.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,7 +21,7 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | ts_filerecord | obs_filerecord)*
 period_fields: ()*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-mst.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-mst.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,7 +24,7 @@ save_flows: "save_flows"i
 first_order_decay: "first_order_decay"i 
 zero_order_decay: "zero_order_decay"i 
 sorption: "sorption"i string
-sorbate_filerecord: "sorbate"i "fileout"i string
+sorbate_filerecord: "sorbate"i "fileout"i word
 export_array_ascii: "export_array_ascii"i 
 export_array_netcdf: "export_array_netcdf"i 
 porosity: "porosity"i array

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-mvt.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-mvt.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,5 +21,5 @@ options_fields: (print_input | print_flows | save_flows | budget_filerecord | bu
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-mwt.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-mwt.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,7 +21,7 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | ts_filerecord | obs_filerecord)*
 period_fields: ()*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-nam.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-nam.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -24,7 +25,7 @@ print_input: "print_input"i
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
 dependent_variable_scaling: "dependent_variable_scaling"i 
-nc_mesh2d_filerecord: "netcdf_mesh2d"i "fileout"i string
-nc_structured_filerecord: "netcdf_structured"i "fileout"i string
-nc_filerecord: "netcdf"i "filein"i string
-packages: "packages"i recarray
+nc_mesh2d_filerecord: "netcdf_mesh2d"i "fileout"i word
+nc_structured_filerecord: "netcdf_structured"i "fileout"i word
+nc_filerecord: "netcdf"i "filein"i word
+packages: "packages"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-oc.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-oc.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,9 +21,16 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | concentration_filerecord | concentrationprintrecord)*
 period_fields: (saverecord | printrecord)*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-concentration_filerecord: "fileout"i "concentration"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+concentration_filerecord: "concentration"i "fileout"i word
 concentrationprintrecord: "concentration"i "print_format"i
-saverecord: "save"i string keystring
-printrecord: "print"i string keystring
+saverecord: "save"i word ocsetting
+printrecord: "print"i word ocsetting
+ocsetting: ocsetting_all | ocsetting_first | ocsetting_last | ocsetting_frequency | ocsetting_steps
+ocsetting_all: "all"i
+ocsetting_first: "first"i
+ocsetting_last: "last"i
+ocsetting_frequency: "frequency"i integer
+ocsetting_steps: "steps"i integer+
+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-sft.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-sft.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,7 +21,7 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | ts_filerecord | obs_filerecord)*
 period_fields: ()*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-src.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-src.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,8 +29,8 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 highest_saturated: "highest_saturated"i 
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-ssm.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-ssm.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -21,4 +22,4 @@ options_fields: (print_flows | save_flows)*
 fileinput_fields: (fileinput)*
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-fileinput: "fileinput"i recarray
+fileinput: "fileinput"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/gwt-uzt.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/gwt-uzt.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,7 +21,7 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | ts_filerecord | obs_filerecord)*
 period_fields: ()*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-cdb.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-cdb.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,6 +28,6 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-obs_filerecord: "filein"i "obs6"i string
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-chd.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-chd.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-cxs.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-cxs.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -26,5 +27,5 @@ crosssectiondata_fields: (crosssectiondata)*
 print_input: "print_input"i 
 nsections: "nsections"i integer
 npoints: "npoints"i integer
-packagedata: "packagedata"i recarray
-crosssectiondata: "crosssectiondata"i recarray
+packagedata: "packagedata"i list
+crosssectiondata: "crosssectiondata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-dfw.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-dfw.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -25,7 +26,7 @@ time_conversion: "time_conversion"i double
 save_flows: "save_flows"i 
 print_flows: "print_flows"i 
 save_velocity: "save_velocity"i 
-obs_filerecord: "obs6"i "filein"i string
+obs_filerecord: "obs6"i "filein"i word
 export_array_ascii: "export_array_ascii"i 
 dev_swr_conductance: "dev_swr_conductance"i 
 manningsn: "manningsn"i array

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-dis2d.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-dis2d.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,7 +24,7 @@ dimensions_fields: (nrow | ncol)*
 griddata_fields: (delr | delc | bottom | idomain)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-disv1d.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-disv1d.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,7 +28,7 @@ vertices_fields: (vertices)*
 cell2d_fields: (cell2d)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
@@ -39,5 +40,5 @@ length: "length"i array
 width: "width"i array
 bottom: "bottom"i array
 idomain: "idomain"i array
-vertices: "vertices"i recarray
-cell2d: "cell2d"i recarray
+vertices: "vertices"i list
+cell2d: "cell2d"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-disv2d.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-disv2d.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,7 +28,7 @@ vertices_fields: (vertices)*
 cell2d_fields: (cell2d)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
@@ -37,5 +38,5 @@ nodes: "nodes"i integer
 nvert: "nvert"i integer
 bottom: "bottom"i array
 idomain: "idomain"i array
-vertices: "vertices"i recarray
-cell2d: "cell2d"i recarray
+vertices: "vertices"i list
+cell2d: "cell2d"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-evp.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-evp.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-flw.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-flw.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-ic.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-ic.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-nam.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-nam.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -24,4 +25,4 @@ print_input: "print_input"i
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
 newtonoptions: "newton"i "under_relaxation"i
-packages: "packages"i recarray
+packages: "packages"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-oc.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-oc.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,10 +21,17 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | qoutflow_filerecord | stage_filerecord | qoutflowprintrecord)*
 period_fields: (saverecord | printrecord)*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-qoutflow_filerecord: "fileout"i "qoutflow"i string
-stage_filerecord: "fileout"i "stage"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+qoutflow_filerecord: "qoutflow"i "fileout"i word
+stage_filerecord: "stage"i "fileout"i word
 qoutflowprintrecord: "qoutflow"i "print_format"i
-saverecord: "save"i string keystring
-printrecord: "print"i string keystring
+saverecord: "save"i word ocsetting
+printrecord: "print"i word ocsetting
+ocsetting: ocsetting_all | ocsetting_first | ocsetting_last | ocsetting_frequency | ocsetting_steps
+ocsetting_all: "all"i
+ocsetting_first: "first"i
+ocsetting_last: "last"i
+ocsetting_frequency: "frequency"i integer
+ocsetting_steps: "steps"i integer+
+

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-pcp.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-pcp.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-sto.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-sto.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/olf-zdg.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/olf-zdg.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,7 +28,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/prt-dis.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/prt-dis.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,14 +24,14 @@ dimensions_fields: (nlay | nrow | ncol)*
 griddata_fields: (delr | delc | top | botm | idomain)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
 export_array_ascii: "export_array_ascii"i 
 export_array_netcdf: "export_array_netcdf"i 
 crs: "crs"i array
-ncf_filerecord: "ncf6"i "filein"i string
+ncf_filerecord: "ncf6"i "filein"i word
 nlay: "nlay"i integer
 nrow: "nrow"i integer
 ncol: "ncol"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/prt-disv.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/prt-disv.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,19 +28,19 @@ vertices_fields: (vertices)*
 cell2d_fields: (cell2d)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
 export_array_ascii: "export_array_ascii"i 
 export_array_netcdf: "export_array_netcdf"i 
 crs: "crs"i array
-ncf_filerecord: "ncf6"i "filein"i string
+ncf_filerecord: "ncf6"i "filein"i word
 nlay: "nlay"i integer
 ncpl: "ncpl"i integer
 nvert: "nvert"i integer
 top: "top"i array
 botm: "botm"i array
 idomain: "idomain"i array
-vertices: "vertices"i recarray
-cell2d: "cell2d"i recarray
+vertices: "vertices"i list
+cell2d: "cell2d"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/prt-fmi.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/prt-fmi.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,4 +21,4 @@ packagedata_block: "begin"i "packagedata"i packagedata_fields "end"i "packagedat
 options_fields: (save_flows)*
 packagedata_fields: (packagedata)*
 save_flows: "save_flows"i 
-packagedata: "packagedata"i recarray
+packagedata: "packagedata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/prt-mip.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/prt-mip.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/prt-nam.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/prt-nam.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,4 +24,4 @@ list: "list"i string
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-packages: "packages"i recarray
+packages: "packages"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/prt-oc.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/prt-oc.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -24,10 +25,10 @@ options_fields: (budget_filerecord | budgetcsv_filerecord | track_filerecord | t
 dimensions_fields: (ntracktimes)*
 period_fields: (saverecord | printrecord)*
 tracktimes_fields: (tracktimes)*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-track_filerecord: "fileout"i "track"i string
-trackcsv_filerecord: "fileout"i "trackcsv"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+track_filerecord: "track"i "fileout"i word
+trackcsv_filerecord: "trackcsv"i "fileout"i word
 track_release: "track_release"i 
 track_exit: "track_exit"i 
 track_subfeature_exit: "track_subfeature_exit"i 
@@ -37,9 +38,16 @@ track_weaksink: "track_weaksink"i
 track_usertime: "track_usertime"i 
 track_dropped: "track_dropped"i 
 track_timesrecord: "track_times"i double
-track_timesfilerecord: "track_timesfile"i string
+track_timesfilerecord: "track_timesfile"i word
 dev_dump_event_trace: "dev_dump_event_trace"i 
 ntracktimes: "ntracktimes"i integer
-saverecord: "save"i string keystring
-printrecord: "print"i string keystring
-tracktimes: "tracktimes"i recarray
+saverecord: "save"i word ocsetting
+printrecord: "print"i word ocsetting
+tracktimes: "tracktimes"i list
+ocsetting: ocsetting_all | ocsetting_first | ocsetting_last | ocsetting_frequency | ocsetting_steps
+ocsetting_all: "all"i
+ocsetting_first: "first"i
+ocsetting_last: "last"i
+ocsetting_frequency: "frequency"i integer
+ocsetting_steps: "steps"i integer+
+

--- a/flopy4/mf6/codec/reader/grammar/generated/prt-prp.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/prt-prp.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -32,15 +33,15 @@ dev_exit_solve_method: "dev_exit_solve_method"i integer
 exit_solve_tolerance: "exit_solve_tolerance"i double
 local_z: "local_z"i 
 extend_tracking: "extend_tracking"i 
-track_filerecord: "track"i "fileout"i string
-trackcsv_filerecord: "fileout"i "trackcsv"i string
+track_filerecord: "track"i "fileout"i word
+trackcsv_filerecord: "trackcsv"i "fileout"i word
 stoptime: "stoptime"i double
 stoptraveltime: "stoptraveltime"i double
 stop_at_weak_sink: "stop_at_weak_sink"i 
 istopzone: "istopzone"i integer
 drape: "drape"i 
 release_timesrecord: "release_times"i double
-release_timesfilerecord: "release_timesfile"i string
+release_timesfilerecord: "release_timesfile"i word
 dry_tracking_method: "dry_tracking_method"i string
 dev_forceternary: "dev_forceternary"i 
 release_time_tolerance: "release_time_tolerance"i double
@@ -49,9 +50,9 @@ coordinate_check_method: "coordinate_check_method"i string
 dev_cycle_detection_window: "dev_cycle_detection_window"i integer
 nreleasepts: "nreleasepts"i integer
 nreleasetimes: "nreleasetimes"i integer
-packagedata: "packagedata"i recarray
+packagedata: "packagedata"i list
 all: "all"i 
 first: "first"i 
 last: "last"i 
-releasetimes: "releasetimes"i recarray
+releasetimes: "releasetimes"i list
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/sim-nam.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/sim-nam.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -31,9 +32,9 @@ memory_print_option: "memory_print_option"i string
 profile_option: "profile_option"i string
 maxerrors: "maxerrors"i integer
 print_input: "print_input"i 
-hpc_filerecord: "hpc6"i "filein"i string
+hpc_filerecord: "hpc6"i "filein"i word
 tdis6: "tdis6"i string
-models: "models"i recarray
-exchanges: "exchanges"i recarray
+models: "models"i list
+exchanges: "exchanges"i list
 mxiter: "mxiter"i integer
-solutiongroup: "solutiongroup"i recarray
+solutiongroup: "solutiongroup"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/sim-tdis.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/sim-tdis.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,6 +24,6 @@ dimensions_fields: (nper)*
 perioddata_fields: (perioddata)*
 time_units: "time_units"i string
 start_date_time: "start_date_time"i string
-ats_filerecord: "ats6"i "filein"i string
+ats_filerecord: "ats6"i "filein"i word
 nper: "nper"i integer
-perioddata: "perioddata"i recarray
+perioddata: "perioddata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/sln-ems.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/sln-ems.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/sln-ims.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/sln-ims.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,10 +24,10 @@ nonlinear_fields: (outer_hclose | outer_dvclose | outer_rclosebnd | outer_maximu
 linear_fields: (inner_maximum | inner_hclose | inner_dvclose | rcloserecord | linear_acceleration | relaxation_factor | preconditioner_levels | preconditioner_drop_tolerance | number_orthogonalizations | scaling_method | reordering_method)*
 print_option: "print_option"i string
 complexity: "complexity"i string
-csv_output_filerecord: "csv_output"i string "fileout"i
-csv_outer_output_filerecord: "csv_outer_output"i "fileout"i string
-csv_inner_output_filerecord: "fileout"i "csv_inner_output"i string
-no_ptcrecord: "no_ptc"i string
+csv_output_filerecord: "csv_output"i "fileout"i word
+csv_outer_output_filerecord: "csv_outer_output"i "fileout"i word
+csv_inner_output_filerecord: "csv_inner_output"i "fileout"i word
+no_ptcrecord: "no_ptc"i word
 ats_outer_maximum_fraction: "ats_outer_maximum_fraction"i double
 outer_hclose: "outer_hclose"i double
 outer_dvclose: "outer_dvclose"i double
@@ -44,7 +45,7 @@ backtracking_residual_limit: "backtracking_residual_limit"i double
 inner_maximum: "inner_maximum"i integer
 inner_hclose: "inner_hclose"i double
 inner_dvclose: "inner_dvclose"i double
-rcloserecord: double string
+rcloserecord: double word
 linear_acceleration: "linear_acceleration"i string
 relaxation_factor: "relaxation_factor"i double
 preconditioner_levels: "preconditioner_levels"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/sln-pts.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/sln-pts.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -21,9 +22,9 @@ options_fields: (print_option | complexity | csv_output_filerecord | csv_outer_o
 nonlinear_fields: (outer_maximum)*
 print_option: "print_option"i string
 complexity: "complexity"i string
-csv_output_filerecord: "csv_output"i string "fileout"i
-csv_outer_output_filerecord: "csv_outer_output"i "fileout"i string
-csv_inner_output_filerecord: "fileout"i "csv_inner_output"i string
-no_ptcrecord: "no_ptc"i string
+csv_output_filerecord: "csv_output"i "fileout"i word
+csv_outer_output_filerecord: "csv_outer_output"i "fileout"i word
+csv_inner_output_filerecord: "csv_inner_output"i "fileout"i word
+no_ptcrecord: "no_ptc"i word
 ats_outer_maximum_fraction: "ats_outer_maximum_fraction"i double
 outer_maximum: "outer_maximum"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-cdb.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-cdb.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,6 +28,6 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-obs_filerecord: "filein"i "obs6"i string
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-chd.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-chd.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-cxs.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-cxs.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -26,5 +27,5 @@ crosssectiondata_fields: (crosssectiondata)*
 print_input: "print_input"i 
 nsections: "nsections"i integer
 npoints: "npoints"i integer
-packagedata: "packagedata"i recarray
-crosssectiondata: "crosssectiondata"i recarray
+packagedata: "packagedata"i list
+crosssectiondata: "crosssectiondata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-dfw.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-dfw.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -25,7 +26,7 @@ time_conversion: "time_conversion"i double
 save_flows: "save_flows"i 
 print_flows: "print_flows"i 
 save_velocity: "save_velocity"i 
-obs_filerecord: "obs6"i "filein"i string
+obs_filerecord: "obs6"i "filein"i word
 export_array_ascii: "export_array_ascii"i 
 dev_swr_conductance: "dev_swr_conductance"i 
 manningsn: "manningsn"i array

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-dis2d.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-dis2d.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,7 +24,7 @@ dimensions_fields: (nrow | ncol)*
 griddata_fields: (delr | delc | bottom | idomain)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-disv1d.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-disv1d.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,7 +28,7 @@ vertices_fields: (vertices)*
 cell1d_fields: (cell1d)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
@@ -38,5 +39,5 @@ nvert: "nvert"i integer
 width: "width"i array
 bottom: "bottom"i array
 idomain: "idomain"i array
-vertices: "vertices"i recarray
-cell1d: "cell1d"i recarray
+vertices: "vertices"i list
+cell1d: "cell1d"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-disv2d.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-disv2d.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,7 +28,7 @@ vertices_fields: (vertices)*
 cell2d_fields: (cell2d)*
 length_units: "length_units"i string
 nogrb: "nogrb"i 
-grb_filerecord: "grb6"i "fileout"i string
+grb_filerecord: "grb6"i "fileout"i word
 xorigin: "xorigin"i double
 yorigin: "yorigin"i double
 angrot: "angrot"i double
@@ -37,5 +38,5 @@ nodes: "nodes"i integer
 nvert: "nvert"i integer
 bottom: "bottom"i array
 idomain: "idomain"i array
-vertices: "vertices"i recarray
-cell2d: "cell2d"i recarray
+vertices: "vertices"i list
+cell2d: "cell2d"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-evp.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-evp.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-flw.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-flw.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-ic.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-ic.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-nam.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-nam.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -24,4 +25,4 @@ print_input: "print_input"i
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
 newtonoptions: "newton"i "under_relaxation"i
-packages: "packages"i recarray
+packages: "packages"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-oc.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-oc.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,10 +21,17 @@ period_block: "begin"i "period"i block_index period_fields "end"i "period"i bloc
 block_index: integer
 options_fields: (budget_filerecord | budgetcsv_filerecord | qoutflow_filerecord | stage_filerecord | qoutflowprintrecord)*
 period_fields: (saverecord | printrecord)*
-budget_filerecord: "budget"i "fileout"i string
-budgetcsv_filerecord: "fileout"i "budgetcsv"i string
-qoutflow_filerecord: "fileout"i "qoutflow"i string
-stage_filerecord: "fileout"i "stage"i string
+budget_filerecord: "budget"i "fileout"i word
+budgetcsv_filerecord: "budgetcsv"i "fileout"i word
+qoutflow_filerecord: "qoutflow"i "fileout"i word
+stage_filerecord: "stage"i "fileout"i word
 qoutflowprintrecord: "qoutflow"i "print_format"i
-saverecord: "save"i string keystring
-printrecord: "print"i string keystring
+saverecord: "save"i word ocsetting
+printrecord: "print"i word ocsetting
+ocsetting: ocsetting_all | ocsetting_first | ocsetting_last | ocsetting_frequency | ocsetting_steps
+ocsetting_all: "all"i
+ocsetting_first: "first"i
+ocsetting_last: "last"i
+ocsetting_frequency: "frequency"i integer
+ocsetting_steps: "steps"i integer+
+

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-pcp.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-pcp.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -28,7 +29,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-sto.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-sto.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/swf-zdg.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/swf-zdg.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -27,7 +28,7 @@ boundnames: "boundnames"i
 print_input: "print_input"i 
 print_flows: "print_flows"i 
 save_flows: "save_flows"i 
-ts_filerecord: "ts6"i "filein"i string
-obs_filerecord: "filein"i "obs6"i string
+ts_filerecord: "ts6"i "filein"i word
+obs_filerecord: "obs6"i "filein"i word
 maxbound: "maxbound"i integer
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/utl-ats.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/utl-ats.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -20,4 +21,4 @@ perioddata_block: "begin"i "perioddata"i perioddata_fields "end"i "perioddata"i
 dimensions_fields: (maxats)*
 perioddata_fields: (perioddata)*
 maxats: "maxats"i integer
-perioddata: "perioddata"i recarray
+perioddata: "perioddata"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/utl-hpc.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/utl-hpc.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -21,4 +22,4 @@ options_fields: (print_table | dev_log_mpi)*
 partitions_fields: (partitions)*
 print_table: "print_table"i 
 dev_log_mpi: "dev_log_mpi"i 
-partitions: "partitions"i recarray
+partitions: "partitions"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/utl-laktab.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/utl-laktab.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -21,4 +22,4 @@ dimensions_fields: (nrow | ncol)*
 table_fields: (table)*
 nrow: "nrow"i integer
 ncol: "ncol"i integer
-table: "table"i recarray
+table: "table"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/utl-ncf.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/utl-ncf.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/generated/utl-obs.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/utl-obs.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -21,4 +22,4 @@ options_fields: (digits | print_input)*
 continuous_fields: (continuous)*
 digits: "digits"i integer
 print_input: "print_input"i 
-continuous: "continuous"i recarray
+continuous: "continuous"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/utl-sfrtab.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/utl-sfrtab.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -21,4 +22,4 @@ dimensions_fields: (nrow | ncol)*
 table_fields: (table)*
 nrow: "nrow"i integer
 ncol: "ncol"i integer
-table: "table"i recarray
+table: "table"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/utl-spc.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/utl-spc.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -23,5 +24,5 @@ options_fields: (print_input | ts_filerecord)*
 dimensions_fields: (maxbound)*
 period_fields: ()*
 print_input: "print_input"i 
-ts_filerecord: "ts6"i "filein"i string
+ts_filerecord: "ts6"i "filein"i word
 maxbound: "maxbound"i integer

--- a/flopy4/mf6/codec/reader/grammar/generated/utl-spca.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/utl-spca.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -22,5 +23,5 @@ options_fields: (readasarrays | print_input | tas_filerecord)*
 period_fields: (stress_period_data)*
 readasarrays: "readasarrays"i 
 print_input: "print_input"i 
-tas_filerecord: "tas6"i "filein"i string
+tas_filerecord: "tas6"i "filein"i word
 stress_period_data: record+

--- a/flopy4/mf6/codec/reader/grammar/generated/utl-tas.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/utl-tas.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -19,7 +20,7 @@ attributes_block: "begin"i "attributes"i attributes_fields "end"i "attributes"i
 time_block: "begin"i "time"i time_fields "end"i "time"i
 attributes_fields: (time_series_namerecord | interpolation_methodrecord | sfacrecord)*
 time_fields: (tas_array)*
-time_series_namerecord: "name"i string
-interpolation_methodrecord: "method"i string
+time_series_namerecord: "name"i word
+interpolation_methodrecord: "method"i word
 sfacrecord: "sfac"i double
 tas_array: "tas_array"i array

--- a/flopy4/mf6/codec/reader/grammar/generated/utl-ts.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/utl-ts.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -19,12 +20,12 @@ attributes_block: "begin"i "attributes"i attributes_fields "end"i "attributes"i
 timeseries_block: "begin"i "timeseries"i timeseries_fields "end"i "timeseries"i
 attributes_fields: (time_series_namerecord | interpolation_methodrecord | interpolation_methodrecord_single | method | interpolation_method_single | sfacrecord | sfacrecord_single | sfac)*
 timeseries_fields: (timeseries)*
-time_series_namerecord: "names"i string
-interpolation_methodrecord: "methods"i string
+time_series_namerecord: "names"i word
+interpolation_methodrecord: "methods"i word
 interpolation_methodrecord_single: 
 method: "method"i 
 interpolation_method_single: "interpolation_method_single"i string
 sfacrecord: "sfacs"i double
 sfacrecord_single: double
 sfac: "sfac"i 
-timeseries: "timeseries"i recarray
+timeseries: "timeseries"i list

--- a/flopy4/mf6/codec/reader/grammar/generated/utl-tvk.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/utl-tvk.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -21,4 +22,4 @@ block_index: integer
 options_fields: (print_input | ts_filerecord)*
 period_fields: ()*
 print_input: "print_input"i 
-ts_filerecord: "ts6"i "filein"i string
+ts_filerecord: "ts6"i "filein"i word

--- a/flopy4/mf6/codec/reader/grammar/generated/utl-tvs.lark
+++ b/flopy4/mf6/codec/reader/grammar/generated/utl-tvs.lark
@@ -4,6 +4,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE
@@ -22,4 +23,4 @@ options_fields: (disable_storage_change_integration | print_input | ts_filerecor
 period_fields: ()*
 disable_storage_change_integration: "disable_storage_change_integration"i 
 print_input: "print_input"i 
-ts_filerecord: "ts6"i "filein"i string
+ts_filerecord: "ts6"i "filein"i word

--- a/flopy4/mf6/codec/reader/grammar/templates/component.lark.jinja
+++ b/flopy4/mf6/codec/reader/grammar/templates/component.lark.jinja
@@ -5,6 +5,7 @@
 %import typed.double -> double
 %import typed.number -> number
 %import typed.string -> string
+%import typed.word -> word
 %import typed.array -> array
 %import typed.record -> record
 %import typed.NEWLINE -> NEWLINE

--- a/flopy4/mf6/codec/reader/grammar/templates/macros.jinja
+++ b/flopy4/mf6/codec/reader/grammar/templates/macros.jinja
@@ -37,12 +37,14 @@
 {{ child_name }}_{{ opt_name }}
 {%- if not loop.last %} | {% endif -%}
 {%- endfor %}
+
 {% for opt_name, opt in child.children.items() -%}
 {{ child_name }}_{{ opt_name }}: {% if opt.type == 'keyword' -%}
 "{{ opt.name }}"i
 {%- else -%}
-"{{ opt.name }}"i {{ opt.type }}
+"{{ opt.name }}"i {{ opt.type }}{% if opt.shape %}+{% endif %}
 {%- endif %}
+
 {% endfor -%}
 {%- endmacro %}
 

--- a/flopy4/mf6/codec/reader/transformer.py
+++ b/flopy4/mf6/codec/reader/transformer.py
@@ -69,6 +69,22 @@ class TypedTransformer(Transformer):
         self.dfn = dfn
         self.blocks = dfn.blocks if dfn else None
         self.fields = dfn.fields if dfn else None
+        # Create a flattened fields dict that includes nested fields
+        self._flat_fields = self._flatten_fields(self.fields) if self.fields else None
+
+    def _flatten_fields(self, fields: dict) -> dict:
+        """Recursively flatten fields dict to include children of records and unions."""
+        flat = dict(fields)  # Start with top-level fields
+        for field in fields.values():
+            if hasattr(field, "children") and field.children:
+                # Add children fields
+                for child_name, child_field in field.children.items():
+                    flat[child_name] = child_field
+                    # Recursively flatten nested children
+                    if hasattr(child_field, "children") and child_field.children:
+                        nested_flat = self._flatten_fields(child_field.children)
+                        flat.update(nested_flat)
+        return flat
 
     def start(self, items: list[Any]) -> dict:
         """Collect and merge blocks, handling indexed blocks specially."""
@@ -171,6 +187,10 @@ class TypedTransformer(Transformer):
         """Handle simple string (unquoted word or escaped string)."""
         return str(items[0]).strip("\"'")
 
+    def word(self, items: list[Token]) -> str:
+        """Handle word token."""
+        return str(items[0])
+
     def integer(self, items: list[Any]) -> int:
         return int(items[0])
 
@@ -241,7 +261,7 @@ class TypedTransformer(Transformer):
         return array_info
 
     def __default__(self, data, children, meta):
-        if self.blocks is None or self.fields is None:
+        if self.blocks is None or self._flat_fields is None:
             return super().__default__(data, children, meta)
         if data.endswith("_block") and (block_name := data[:-6]) in self.blocks:
             # See if this is an indexed block (period blocks have 3 children: index, fields, index
@@ -269,11 +289,65 @@ class TypedTransformer(Transformer):
                 else:
                     # Fallback to original behavior
                     return {"stress_period_data": children}
-            return {item[0].lower(): item[1] for item in children}
-        elif (field := self.fields.get(data, None)) is not None:
+            # Group fields by name to handle repeated fields
+            fields_dict = {}
+            for item in children:
+                if isinstance(item, tuple):
+                    field_name = item[0].lower()
+                    field_value = item[1]
+                    if field_name in fields_dict:
+                        # Multiple occurrences - convert to list or append
+                        if not isinstance(fields_dict[field_name], list):
+                            fields_dict[field_name] = [fields_dict[field_name]]
+                        fields_dict[field_name].append(field_value)
+                    else:
+                        fields_dict[field_name] = field_value
+            return fields_dict
+        elif "_" in data and (parts := data.rsplit("_", 1)) and len(parts) == 2:
+            # Check if this is a union alternative (e.g., ocsetting_all)
+            field_name, alternative_name = parts
+            if (parent_field := self._flat_fields.get(field_name, None)) is not None:
+                if (
+                    parent_field.type == "union"
+                    and hasattr(parent_field, "children")
+                    and parent_field.children
+                    and alternative_name in parent_field.children
+                ):
+                    # This is a union alternative
+                    alt_field = parent_field.children[alternative_name]
+                    if alt_field.type == "keyword":
+                        # Keyword alternatives return just the alternative name
+                        return alternative_name
+                    else:
+                        # Non-keyword alternatives return the transformed children
+                        return children[0] if len(children) == 1 else children
+        if (field := self._flat_fields.get(data, None)) is not None:
             if field.type == "keyword":
                 return data, True
+            elif field.type == "record" and hasattr(field, "children") and field.children:
+                # Transform record fields into dicts with child field names as keys
+                # Keyword children are literals in the grammar and don't appear in children list
+                # Only non-keyword children appear in the children list
+                record_dict = {}
+                non_keyword_children = [
+                    (name, child)
+                    for name, child in field.children.items()
+                    if child.type != "keyword"
+                ]
+                for i, (child_name, child_field) in enumerate(non_keyword_children):
+                    if i < len(children):
+                        # Handle tuples from transformed fields
+                        if isinstance(children[i], tuple) and children[i][0] == child_name:
+                            record_dict[child_name] = children[i][1]
+                        else:
+                            record_dict[child_name] = children[i]
+                return data, record_dict
+            elif field.type == "union" and hasattr(field, "children") and field.children:
+                # For union fields, return the transformed child
+                # The parser will have selected one alternative
+                return data, children[0] if len(children) == 1 else children
             else:
-                # For all other fields (including arrays), return the transformed children
+                # For all fields, return the transformed children
+                # (arrays have already been transformed by the array method)
                 return data, children[0] if len(children) == 1 else children
         return super().__default__(data, children, meta)

--- a/pixi.lock
+++ b/pixi.lock
@@ -62,7 +62,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/97/12/a1f2f4fdc6b7159c0d12249456f9fe454665b6126e98dbee9f2bd3cf735c/lz4-4.4.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/22/ff/6425bf5c20d79aa5b959d1ce9e65f599632345391381c9a104133fe0b171/matplotlib-3.10.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/1a/78b19893197ed7525edfa7f124a461626541e82aec694a468ba97755c24e/netcdf4-1.7.3-cp311-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
@@ -104,7 +104,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/bd/c336448be43d40be28e71f2e0f3caf7ccb28e2755c58f4c02c065bfe3e8e/WebOb-1.8.9-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -157,7 +157,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3b/3c/d1d1b926d3688263893461e7c47ed7382a969a0976fc121fc678ec325fc6/lz4-4.4.4-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/02/9c/207547916a02c78f6bdd83448d9b21afbc42f6379ed887ecf610984f3b4e/matplotlib-3.10.7-cp313-cp313-macosx_10_13_x86_64.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/49/62/d286c76cdf0f6faf6064dc032ba7df3d6172ccca6e7d3571eee5516661b9/netcdf4-1.7.3-cp311-abi3-macosx_13_0_x86_64.whl
@@ -199,7 +199,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/bd/c336448be43d40be28e71f2e0f3caf7ccb28e2755c58f4c02c065bfe3e8e/WebOb-1.8.9-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -255,7 +255,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/00/96/b8e24ea7537ab418074c226279acfcaa470e1ea8271003e24909b6db942b/lz4-4.4.4-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e1/b6/23064a96308b9aeceeffa65e96bcde459a2ea4934d311dee20afde7407a0/matplotlib-3.10.7-cp313-cp313-win_amd64.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/f8/a5509bc46faedae2b71df29c57e6525b7eb47aee44000fd43e2927a9a3a9/netcdf4-1.7.3-cp311-abi3-win_amd64.whl
@@ -297,7 +297,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/bd/c336448be43d40be28e71f2e0f3caf7ccb28e2755c58f4c02c065bfe3e8e/WebOb-1.8.9-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -432,7 +432,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/da/e0/6cc2e852837cd6086fe7d8406af4294e66827a60a4cf60b86575a4a65ca8/msgpack-1.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1a/52/ec4a061dd599eb8179d5411d99775bec2a20542505988f40fc2fee781068/mypy-1.18.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -535,7 +535,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -653,7 +653,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/97/560d11202bcd537abca693fd85d81cebe2107ba17301de42b01ac1677b69/msgpack-1.1.2-cp311-cp311-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/88/87/cafd3ae563f88f94eec33f35ff722d043e09832ea8530ef149ec1efbaf08/mypy-1.18.2-cp311-cp311-macosx_10_9_x86_64.whl
@@ -755,7 +755,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -875,7 +875,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/79/309d0e637f6f37e83c711f547308b91af02b72d2326ddd860b966080ef29/msgpack-1.1.2-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c8/7d/2697b930179e7277529eaaec1513f8de622818696857f689e4a5432e5e27/mypy-1.18.2-cp311-cp311-win_amd64.whl
@@ -977,7 +977,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -1099,7 +1099,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/da/e0/6cc2e852837cd6086fe7d8406af4294e66827a60a4cf60b86575a4a65ca8/msgpack-1.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
@@ -1186,7 +1186,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -1292,7 +1292,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/2c/97/560d11202bcd537abca693fd85d81cebe2107ba17301de42b01ac1677b69/msgpack-1.1.2-cp311-cp311-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
@@ -1379,7 +1379,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -1487,7 +1487,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/2a/79/309d0e637f6f37e83c711f547308b91af02b72d2326ddd860b966080ef29/msgpack-1.1.2-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
@@ -1573,7 +1573,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -1694,7 +1694,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
@@ -1780,7 +1780,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -1884,7 +1884,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
@@ -1970,7 +1970,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -2076,7 +2076,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
@@ -2161,7 +2161,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -2281,7 +2281,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
@@ -2367,7 +2367,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -2474,7 +2474,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
@@ -2560,7 +2560,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -2669,7 +2669,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl
-      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+      - pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
       - pypi: https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/29/13/024ae0586d901f8a6f99e2d29b4ae217e8ef11d3fd944cdfc3bbde5f2a08/narwhals-2.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/34/6d/e7fa07f03a4a7b221d94b4d586edb754a9b0dc3c9e2c93353e9fa4e0d117/nbclient-0.10.2-py3-none-any.whl
@@ -2754,7 +2754,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/51/5447876806d1088a0f8f71e16542bf350918128d0a69437df26047c8e46f/widgetsnbextension-4.0.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/78/4d6d68555a92cb97b4c192759c4ab585c5cb23490f64d4ddf12c66a3b051/xarray-2025.10.1-py3-none-any.whl
-      - pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+      - pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
       - pypi: https://files.pythonhosted.org/packages/d6/7d/b77455d7c7c51255b2992b429107fab811b2e36ceaf76da1e55a045dc568/xyzservices-2025.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/71/9de7229515a53d1cc5705ca9c411530f711a2242f962214d9dbfe2741aa4/zarr-3.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
@@ -6177,7 +6177,7 @@ packages:
   requires_dist:
   - typing-extensions ; python_full_version < '3.11'
   requires_python: '>=3.8'
-- pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#5cc232ec71f5493ae9190a46e42dc1e8ecbba5aa
+- pypi: git+https://github.com/MODFLOW-ORG/modflow-devtools.git?rev=dfn#618f8eeb957b9306f17997c0c6ce0d5af532fdf4
   name: modflow-devtools
   version: 1.8.0.dev0
   requires_dist:
@@ -10093,7 +10093,7 @@ packages:
   - types-requests ; extra == 'types'
   - types-setuptools ; extra == 'types'
   requires_python: '>=3.11'
-- pypi: git+https://github.com/wpbonelli/xattree.git#775f910c07ed8426d6a7cc704177cd4c59ecb397
+- pypi: git+https://github.com/wpbonelli/xattree.git#ebc4d5c2593fba4cf2c3e40c5c32b52debd3e989
   name: xattree
   version: 0.1.0.dev0
   requires_dist:

--- a/test/test_mf6_grammar_gen.py
+++ b/test/test_mf6_grammar_gen.py
@@ -217,3 +217,48 @@ def test_make_grammar_with_named_subfields(tmp_path):
     stress_period_data_line = [l for l in lines if l.strip().startswith("stress_period_data:")][0]
     # Should accept both numbers and simple strings
     assert "record" in stress_period_data_line
+
+
+def test_make_grammar_with_oc_style_records(tmp_path):
+    """Test grammar generation for OC-style records with union fields."""
+    dfn = Dfn(
+        schema_version=Version("2.0.0"),
+        name="gwf-oc",
+        blocks={
+            "period": {
+                "saverecord": FieldV2(
+                    name="saverecord",
+                    type="record",
+                    block="period",
+                    children={
+                        "save": FieldV2(name="save", type="keyword", block="period"),
+                        "rtype": FieldV2(name="rtype", type="string", block="period"),
+                        "ocsetting": FieldV2(
+                            name="ocsetting",
+                            type="union",
+                            block="period",
+                            children={
+                                "all": FieldV2(name="all", type="keyword", block="period"),
+                                "first": FieldV2(name="first", type="keyword", block="period"),
+                                "last": FieldV2(name="last", type="keyword", block="period"),
+                            },
+                        ),
+                    },
+                )
+            }
+        },
+    )
+
+    make_grammar(dfn, tmp_path)
+
+    grammar_file = tmp_path / "gwf-oc.lark"
+    content = grammar_file.read_text()
+
+    # Should generate a record rule with keyword, word (not string), and union
+    assert 'saverecord: "save"i word ocsetting' in content
+
+    # Should generate the union rule for ocsetting
+    assert "ocsetting:" in content
+    assert "ocsetting_all" in content
+    assert "ocsetting_first" in content
+    assert "ocsetting_last" in content

--- a/test/test_mf6_reader.py
+++ b/test/test_mf6_reader.py
@@ -35,6 +35,30 @@ INTERNAL FACTOR 1.0 IPRN 3
 7.4 3.5 7.8 8.5 7.4 6.8 8.8
     """)
     print(tree.pretty())
+    assert len(tree.children) == 1
+    array = tree.children[0]
+    assert str(array.data) == "array"
+    readarray = array.children[0].children[-1]
+    assert str(readarray.data) == "readarray"
+    control = readarray.children[0]
+    assert str(control.data) == "control"
+    internal = control.children[0]
+    assert str(internal.data) == "internal"
+    assert len(internal.children) == 2
+    factor = internal.children[0]
+    assert str(factor.data) == "factor"
+    assert str(factor.children[0].data) == "double"
+    assert float(factor.children[0].children[0]) == 1.0
+    iprn = internal.children[1]
+    assert str(iprn.data) == "iprn"
+    assert str(iprn.children[0].data) == "integer"
+    assert int(iprn.children[0].children[0]) == 3
+    data = readarray.children[-1]
+    assert len(data.children) == 28
+    assert str(data.children[0].data) == "double"
+    assert str(data.children[-1].data) == "double"
+    assert float(data.children[0].children[0]) == 1.2
+    assert float(data.children[-1].children[0]) == 8.8
 
 
 def test_parse_layered_array():
@@ -43,12 +67,44 @@ def test_parse_layered_array():
 LAYERED
 CONSTANT 1.0
 INTERNAL FACTOR 1.0 IPRN 3
-1.2 3.7 9.3 4.2 2.2 9.9 1.0 
-3.3 4.9 7.3 7.5 8.2 8.7 6.6 
-4.5 5.7 2.2 1.1 1.7 6.7 6.9 
+1.2 3.7 9.3 4.2 2.2 9.9 1.0
+3.3 4.9 7.3 7.5 8.2 8.7 6.6
+4.5 5.7 2.2 1.1 1.7 6.7 6.9
 7.4 3.5 7.8 8.5 7.4 6.8 8.8
     """)
     print(tree.pretty())
+    assert len(tree.children) == 1
+    array = tree.children[0]
+    assert str(array.data) == "array"
+    layered_array = array.children[0]
+    assert str(layered_array.data) == "layered_array"
+    assert len(layered_array.children) == 4  # 2nd item is optional netcdf
+    layered = layered_array.children[0]
+    assert str(layered.data) == "layered"
+    layer1 = layered_array.children[-2]
+    assert str(layer1.data) == "readarray"
+    control1 = layer1.children[0]
+    assert str(control1.data) == "control"
+    constant = control1.children[0]
+    assert str(constant.data) == "constant"
+    assert str(constant.children[0].data) == "double"
+    assert float(constant.children[0].children[0]) == 1.0
+    layer2 = layered_array.children[-1]
+    assert str(layer2.data) == "readarray"
+    control2 = layer2.children[0]
+    assert str(control2.data) == "control"
+    internal = control2.children[0]
+    assert str(internal.data) == "internal"
+    factor = internal.children[0]
+    assert str(factor.data) == "factor"
+    assert float(factor.children[0].children[0]) == 1.0
+    iprn = internal.children[1]
+    assert str(iprn.data) == "iprn"
+    assert int(iprn.children[0].children[0]) == 3
+    data = layer2.children[1]
+    assert len(data.children) == 28
+    assert float(data.children[0].children[0]) == 1.2
+    assert float(data.children[-1].children[0]) == 8.8
 
 
 def test_parse_constant_array():
@@ -57,6 +113,19 @@ def test_parse_constant_array():
 CONSTANT 1.0
     """)
     print(tree.pretty())
+    assert len(tree.children) == 1
+    array = tree.children[0]
+    assert str(array.data) == "array"
+    single_array = array.children[0]
+    assert str(single_array.data) == "single_array"
+    readarray = single_array.children[-1]  # optional netcdf comes first
+    assert str(readarray.data) == "readarray"
+    control = readarray.children[0]
+    assert str(control.data) == "control"
+    constant = control.children[0]
+    assert str(constant.data) == "constant"
+    assert str(constant.children[0].data) == "double"
+    assert float(constant.children[0].children[0]) == 1.0
 
 
 def test_parse_external_array_no_quotation_marks():
@@ -65,6 +134,22 @@ def test_parse_external_array_no_quotation_marks():
 OPEN/CLOSE some.file
     """)
     print(tree.pretty())
+    assert len(tree.children) == 1
+    array = tree.children[0]
+    assert str(array.data) == "array"
+    single_array = array.children[0]
+    assert str(single_array.data) == "single_array"
+    readarray = single_array.children[-1]  # optional netcdf comes first
+    assert str(readarray.data) == "readarray"
+    control = readarray.children[0]
+    assert str(control.data) == "control"
+    external = control.children[0]
+    assert str(external.data) == "external"
+    filename = external.children[0]
+    assert str(filename.data) == "filename"
+    # there's an intermediate "word",
+    # TODO any way to get rid of it?
+    assert str(filename.children[0].children[0]) == "some.file"
 
 
 def test_parse_external_array_with_quotation_marks():
@@ -73,6 +158,20 @@ def test_parse_external_array_with_quotation_marks():
 OPEN/CLOSE "some.file"
     """)
     print(tree.pretty())
+    assert len(tree.children) == 1
+    array = tree.children[0]
+    assert str(array.data) == "array"
+    single_array = array.children[0]
+    assert str(single_array.data) == "single_array"
+    readarray = single_array.children[-1]
+    assert str(readarray.data) == "readarray"
+    control = readarray.children[0]
+    assert str(control.data) == "control"
+    external = control.children[0]
+    assert str(external.data) == "external"
+    filename = external.children[0]
+    assert str(filename.data) == "filename"
+    assert str(filename.children[0]) == '"some.file"'
 
 
 def test_transform_internal_array():
@@ -291,9 +390,12 @@ def test_parse_gwf_wel_file(model_workspace):
 def test_transform_gwf_ic_file(model_workspace, dfn_path):
     """Test transforming a parsed GWF IC file into structured data."""
 
-    # Load the DFN for IC
-    dfns = load_flat(dfn_path)
-    ic_dfn = dfns["gwf-ic"]
+    # Load the DFN for IC and convert to V2
+    from modflow_devtools.dfn import MapV1To2
+
+    v1_dfns = load_flat(dfn_path)
+    mapper = MapV1To2()
+    ic_dfn = mapper.map(v1_dfns["gwf-ic"])
 
     # Find the IC file
     ic_files = list(model_workspace.rglob("*.ic"))
@@ -315,14 +417,21 @@ def test_transform_gwf_ic_file(model_workspace, dfn_path):
     assert "griddata" in result  # IC has griddata block
     assert "strt" in result["griddata"]  # Starting heads
 
+    # Check strt field exists (array transformation not fully implemented yet)
+    strt_data = result["griddata"]["strt"]
+    assert strt_data is not None
+
 
 @pytest.mark.parametrize("model_workspace", ["mf6/example/ex-gwf-bcf2ss-p01a"], indirect=True)
 def test_transform_gwf_wel_file(model_workspace, dfn_path):
     """Test transforming a parsed GWF WEL file into structured data."""
 
-    # Load the DFN for WEL
-    dfns = load_flat(dfn_path)
-    wel_dfn = dfns["gwf-wel"]
+    # Load the DFN for WEL and convert to V2
+    from modflow_devtools.dfn import MapV1To2
+
+    v1_dfns = load_flat(dfn_path)
+    mapper = MapV1To2()
+    wel_dfn = mapper.map(v1_dfns["gwf-wel"])
 
     # Find the WEL file
     wel_files = list(model_workspace.rglob("*.wel"))
@@ -345,13 +454,117 @@ def test_transform_gwf_wel_file(model_workspace, dfn_path):
     # Check structure
     assert isinstance(result, dict)
 
+    # Check dimensions block
+    assert "dimensions" in result
+    assert result["dimensions"]["maxbound"] == 2
+
     # Should have a period 2 entry (indexed period blocks are flattened to "period N" keys)
     assert "period 2" in result
     assert "stress_period_data" in result["period 2"]
 
     # Should have 2 rows of data (MAXBOUND = 2)
-    assert len(result["period 2"]["stress_period_data"]) == 2
+    spd = result["period 2"]["stress_period_data"]
+    assert len(spd) == 2
 
     # Each row should have 4 values (cellid components + q value)
-    assert len(result["period 2"]["stress_period_data"][0]) == 4
-    assert len(result["period 2"]["stress_period_data"][1]) == 4
+    assert len(spd[0]) == 4
+    assert len(spd[1]) == 4
+
+    # Check specific values from the file
+    # First well: 2 3 4 -3.5e4
+    assert spd[0][0] == 2  # layer
+    assert spd[0][1] == 3  # row
+    assert spd[0][2] == 4  # col
+    assert spd[0][3] == -3.5e4  # q
+
+    # Second well: 2 8 4 -3.5e4
+    assert spd[1][0] == 2  # layer
+    assert spd[1][1] == 8  # row
+    assert spd[1][2] == 4  # col
+    assert spd[1][3] == -3.5e4  # q
+
+
+@pytest.mark.parametrize("model_workspace", ["mf6/example/ex-gwf-bcf2ss-p01a"], indirect=True)
+def test_parse_gwf_oc_file(model_workspace):
+    """Test parsing a GWF OC (output control) file from a real model."""
+    # Find the OC file in the model workspace
+    oc_files = list(model_workspace.rglob("*.oc"))
+    assert len(oc_files) > 0, "No OC files found in model workspace"
+
+    oc_file = oc_files[0]
+    parser = get_typed_parser("gwf-oc")
+
+    # Read and parse the file
+    with open(oc_file, "r") as f:
+        content = f.read()
+
+    tree = parser.parse(content)
+    assert tree is not None
+
+    # Basic structure checks
+    assert tree.data == "start"
+    assert len(tree.children) > 0  # Should have at least one block
+
+    # Should have blocks
+    blocks = [child for child in tree.children if child.data == "block"]
+    assert len(blocks) > 0
+
+
+@pytest.mark.parametrize("model_workspace", ["mf6/example/ex-gwf-bcf2ss-p01a"], indirect=True)
+def test_transform_gwf_oc_file(model_workspace, dfn_path):
+    """Test transforming a parsed GWF OC file into structured data."""
+
+    # Load the DFN for OC and convert to V2
+    from modflow_devtools.dfn import MapV1To2
+
+    v1_dfns = load_flat(dfn_path)
+    mapper = MapV1To2()
+    oc_dfn = mapper.map(v1_dfns["gwf-oc"])
+
+    # Find the OC file
+    oc_files = list(model_workspace.rglob("*.oc"))
+    assert len(oc_files) > 0
+
+    oc_file = oc_files[0]
+    parser = get_typed_parser("gwf-oc")
+    transformer = TypedTransformer(dfn=oc_dfn)
+
+    # Read, parse, and transform
+    with open(oc_file, "r") as f:
+        content = f.read()
+
+    tree = parser.parse(content)
+    result = transformer.transform(tree)
+
+    # Check structure
+    assert isinstance(result, dict)
+
+    # Check options block
+    assert "options" in result
+    options = result["options"]
+
+    # Should have budget and head fileout records
+    assert "budget_filerecord" in options
+    assert options["budget_filerecord"]["budgetfile"] == "ex-gwf-bcf2ss.cbc"
+
+    assert "head_filerecord" in options
+    assert options["head_filerecord"]["headfile"] == "ex-gwf-bcf2ss.hds"
+
+    # Check period 1 block
+    assert "period 1" in result
+    period_data = result["period 1"]
+
+    # Should have saverecord list with HEAD and BUDGET saves
+    assert "saverecord" in period_data
+    save_records = period_data["saverecord"]
+    assert len(save_records) == 2
+
+    # Check that HEAD and BUDGET are both saved with ALL frequency
+    rtypes = [rec["rtype"] for rec in save_records]
+    assert "HEAD" in rtypes
+    assert "BUDGET" in rtypes
+
+    # Check that all records use ALL frequency
+    for rec in save_records:
+        assert "ocsetting" in rec
+        assert rec["ocsetting"] == "all"


### PR DESCRIPTION
rough but it works. involved a few fixes upstream in devtools,  record subfield order was getting scrambled and some v1 schema things were not getting converted to v2. and a few fixes here, mostly to allow the typed transformer to handle composites i.e. (lists of) records and unions. I think this should generalize pretty well but it needs cleanup/refactoring.

still need an inbound converter. right now we only support array conversion and haven't tried plugging it into the output of the loader.

"for the record", ha, here is what the OC grammar looks like

```lark
// Auto-generated grammar for MF6 GWT-OC

%import typed.integer -> integer
%import typed.double -> double
%import typed.number -> number
%import typed.string -> string
%import typed.word -> word
%import typed.array -> array
%import typed.record -> record
%import typed.NEWLINE -> NEWLINE
%import common.WS
%import common.SH_COMMENT

%ignore WS
%ignore SH_COMMENT

start: block*
block: options_block | period_block
options_block: "begin"i "options"i options_fields "end"i "options"i
period_block: "begin"i "period"i block_index period_fields "end"i "period"i block_index
block_index: integer
options_fields: (budget_filerecord | budgetcsv_filerecord | concentration_filerecord | concentrationprintrecord)*
period_fields: (saverecord | printrecord)*
budget_filerecord: "budget"i "fileout"i word
budgetcsv_filerecord: "budgetcsv"i "fileout"i word
concentration_filerecord: "concentration"i "fileout"i word
concentrationprintrecord: "concentration"i "print_format"i
saverecord: "save"i word ocsetting
printrecord: "print"i word ocsetting
ocsetting: ocsetting_all | ocsetting_first | ocsetting_last | ocsetting_frequency | ocsetting_steps
ocsetting_all: "all"i
ocsetting_first: "first"i
ocsetting_last: "last"i
ocsetting_frequency: "frequency"i integer
ocsetting_steps: "steps"i integer+
```