### PR TITLE
configurable write context

### DIFF
--- a/flopy4/mf6/__init__.py
+++ b/flopy4/mf6/__init__.py
@@ -40,11 +40,16 @@ def _load_toml(path: Path) -> Component:
         return structure(load_toml(fp), path)
 
 
-def _write_mf6(component: Component) -> None:
+def _write_mf6(component: Component, context=None, **kwargs) -> None:
+    from flopy4.mf6.write_context import WriteContext
+
+    # Use provided context or default
+    ctx = context if context is not None else WriteContext.default()
+
     with open(component.path, "w") as fp:
         data = unstructure(component)
         try:
-            dump_mf6(data, fp)
+            dump_mf6(data, fp, context=ctx)
         except Exception as e:
             raise WriteError(
                 f"Failed to write MF6 format file for component '{component.name}' "  # type: ignore

--- a/flopy4/mf6/codec/writer/__init__.py
+++ b/flopy4/mf6/codec/writer/__init__.py
@@ -1,5 +1,5 @@
 import sys
-from typing import IO
+from typing import IO, Optional
 
 import numpy as np
 from jinja2 import Environment, PackageLoader
@@ -19,21 +19,78 @@ _JINJA_ENV.filters["array2chunks"] = writer_filters.array2chunks
 _JINJA_ENV.filters["array2string"] = writer_filters.array2string
 _JINJA_ENV.filters["data2list"] = writer_filters.data2list
 _JINJA_TEMPLATE_NAME = "blocks.jinja"
-_PRINT_OPTIONS = {
-    "precision": 4,
-    "linewidth": sys.maxsize,
-    "threshold": sys.maxsize,
-}
 
 
-def dumps(data) -> str:
+def _get_print_options(context=None):
+    """Get numpy print options from WriteContext."""
+    if context is not None:
+        return context.to_numpy_printoptions()
+    # Default options
+    return {
+        "precision": 4,
+        "linewidth": sys.maxsize,
+        "threshold": sys.maxsize,
+    }
+
+
+def dumps(data, context=None) -> str:
+    """
+    Serialize data to MF6 format string.
+
+    Parameters
+    ----------
+    data : dict
+        Data to serialize
+    context : WriteContext, optional
+        Configuration context for writing
+
+    Returns
+    -------
+    str
+        Serialized MF6 format string
+    """
+    from flopy4.mf6.write_context import WriteContext
+
+    # Store context in filter module for filters to access
+    if context is None:
+        context = WriteContext.default()
+    writer_filters._ACTIVE_CONTEXT = context
+
     template = _JINJA_ENV.get_template(_JINJA_TEMPLATE_NAME)
-    with np.printoptions(**_PRINT_OPTIONS):  # type: ignore
-        return template.render(blocks=data)
+    print_opts = _get_print_options(context)
+    with np.printoptions(**print_opts):  # type: ignore
+        result = template.render(blocks=data)
+
+    # Clean up
+    writer_filters._ACTIVE_CONTEXT = None
+    return result
 
 
-def dump(data, fp: IO[str]) -> None:
+def dump(data, fp: IO[str], context=None) -> None:
+    """
+    Serialize data to MF6 format and write to file.
+
+    Parameters
+    ----------
+    data : dict
+        Data to serialize
+    fp : IO[str]
+        File pointer to write to
+    context : WriteContext, optional
+        Configuration context for writing
+    """
+    from flopy4.mf6.write_context import WriteContext
+
+    # Store context in filter module for filters to access
+    if context is None:
+        context = WriteContext.default()
+    writer_filters._ACTIVE_CONTEXT = context
+
     template = _JINJA_ENV.get_template(_JINJA_TEMPLATE_NAME)
     iterator = template.generate(blocks=data)
-    with np.printoptions(**_PRINT_OPTIONS):  # type: ignore
+    print_opts = _get_print_options(context)
+    with np.printoptions(**print_opts):  # type: ignore
         fp.writelines(iterator)
+
+    # Clean up
+    writer_filters._ACTIVE_CONTEXT = None

--- a/flopy4/mf6/codec/writer/__init__.py
+++ b/flopy4/mf6/codec/writer/__init__.py
@@ -51,18 +51,14 @@ def dumps(data, context=None) -> str:
     """
     from flopy4.mf6.write_context import WriteContext
 
-    # Store context in filter module for filters to access
     if context is None:
         context = WriteContext.default()
-    writer_filters._ACTIVE_CONTEXT = context
 
     template = _JINJA_ENV.get_template(_JINJA_TEMPLATE_NAME)
     print_opts = _get_print_options(context)
     with np.printoptions(**print_opts):  # type: ignore
-        result = template.render(blocks=data)
+        result = template.render(blocks=data, context=context)
 
-    # Clean up
-    writer_filters._ACTIVE_CONTEXT = None
     return result
 
 
@@ -81,16 +77,11 @@ def dump(data, fp: IO[str], context=None) -> None:
     """
     from flopy4.mf6.write_context import WriteContext
 
-    # Store context in filter module for filters to access
     if context is None:
         context = WriteContext.default()
-    writer_filters._ACTIVE_CONTEXT = context
 
     template = _JINJA_ENV.get_template(_JINJA_TEMPLATE_NAME)
-    iterator = template.generate(blocks=data)
+    iterator = template.generate(blocks=data, context=context)
     print_opts = _get_print_options(context)
     with np.printoptions(**print_opts):  # type: ignore
         fp.writelines(iterator)
-
-    # Clean up
-    writer_filters._ACTIVE_CONTEXT = None

--- a/flopy4/mf6/codec/writer/__init__.py
+++ b/flopy4/mf6/codec/writer/__init__.py
@@ -1,5 +1,5 @@
 import sys
-from typing import IO, Optional
+from typing import IO
 
 import numpy as np
 from jinja2 import Environment, PackageLoader

--- a/flopy4/mf6/codec/writer/filters.py
+++ b/flopy4/mf6/codec/writer/filters.py
@@ -1,6 +1,6 @@
 from collections.abc import Hashable, Mapping
 from io import StringIO
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import attrs
 import numpy as np
@@ -10,10 +10,13 @@ from xattree import Scalar
 
 from flopy4.mf6.constants import FILL_DNODATA
 
+if TYPE_CHECKING:
+    from flopy4.mf6.write_context import WriteContext
+
 ArrayHow = Literal["constant", "internal", "external", "layered constant", "layered internal"]
 
 # Module-level variable to store active write context
-_ACTIVE_CONTEXT = None
+_ACTIVE_CONTEXT: "WriteContext | None" = None
 
 
 def array_how(value: xr.DataArray) -> ArrayHow:

--- a/flopy4/mf6/codec/writer/filters.py
+++ b/flopy4/mf6/codec/writer/filters.py
@@ -1,6 +1,6 @@
 from collections.abc import Hashable, Mapping
 from io import StringIO
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 import attrs
 import numpy as np
@@ -10,13 +10,7 @@ from xattree import Scalar
 
 from flopy4.mf6.constants import FILL_DNODATA
 
-if TYPE_CHECKING:
-    from flopy4.mf6.write_context import WriteContext
-
 ArrayHow = Literal["constant", "internal", "external", "layered constant", "layered internal"]
-
-# Module-level variable to store active write context
-_ACTIVE_CONTEXT: "WriteContext | None" = None
 
 
 def array_how(value: xr.DataArray) -> ArrayHow:
@@ -47,14 +41,20 @@ def array_how(value: xr.DataArray) -> ArrayHow:
     raise ValueError(f"Arrays with ndim > 3 are not supported, got ndim={value.ndim}")
 
 
-def array2const(value: xr.DataArray) -> Scalar:
+def array2const(value: xr.DataArray, precision: int = 8) -> Scalar:
+    """
+    Convert array to constant scalar value.
+
+    Parameters
+    ----------
+    value : xr.DataArray
+        Array to convert
+    precision : int, optional
+        Number of decimal places for float output. Default is 8.
+    """
     if np.issubdtype(value.dtype, np.integer):
         return value.max().item()
     if np.issubdtype(value.dtype, np.floating):
-        # Use precision from active context if available
-        precision = 8  # default
-        if _ACTIVE_CONTEXT is not None:
-            precision = _ACTIVE_CONTEXT.float_precision
         return f"{value.max().item():.{precision}f}"
     return value.ravel()[0]
 
@@ -105,7 +105,7 @@ def array2chunks(value: xr.DataArray, chunks: Mapping[Hashable, int] | None = No
         yield np.squeeze(value.values)
 
 
-def array2string(value: NDArray) -> str:
+def array2string(value: NDArray, precision: int = 9) -> str:
     """
     Convert an array to a string. The array can be 1D or 2D.
     If the array is 1D, it is converted to a 1-line string,
@@ -113,6 +113,13 @@ def array2string(value: NDArray) -> str:
     2D, each row becomes a line in the string.
 
     Used for writing array-based input to MF6 input files.
+
+    Parameters
+    ----------
+    value : NDArray
+        Array to convert
+    precision : int, optional
+        Number of decimal places for float output. Default is 9.
     """
     buffer = StringIO()
     value = np.asarray(value)
@@ -123,11 +130,7 @@ def array2string(value: NDArray) -> str:
         value = value[None]
     value = np.atleast_1d(value)
 
-    # Use precision from active context if available
     if np.issubdtype(value.dtype, np.floating):
-        precision = 9  # default
-        if _ACTIVE_CONTEXT is not None:
-            precision = _ACTIVE_CONTEXT.float_precision
         format = f"%.{precision}e"
     elif np.issubdtype(value.dtype, np.integer):
         format = "%d"

--- a/flopy4/mf6/codec/writer/filters.py
+++ b/flopy4/mf6/codec/writer/filters.py
@@ -12,6 +12,9 @@ from flopy4.mf6.constants import FILL_DNODATA
 
 ArrayHow = Literal["constant", "internal", "external", "layered constant", "layered internal"]
 
+# Module-level variable to store active write context
+_ACTIVE_CONTEXT = None
+
 
 def array_how(value: xr.DataArray) -> ArrayHow:
     """
@@ -45,7 +48,11 @@ def array2const(value: xr.DataArray) -> Scalar:
     if np.issubdtype(value.dtype, np.integer):
         return value.max().item()
     if np.issubdtype(value.dtype, np.floating):
-        return f"{value.max().item():.8f}"
+        # Use precision from active context if available
+        precision = 8  # default
+        if _ACTIVE_CONTEXT is not None:
+            precision = _ACTIVE_CONTEXT.float_precision
+        return f"{value.max().item():.{precision}f}"
     return value.ravel()[0]
 
 
@@ -112,13 +119,18 @@ def array2string(value: NDArray) -> str:
         # add an axis to 1d arrays so np.savetxt writes elements on 1 line
         value = value[None]
     value = np.atleast_1d(value)
-    format = (
-        "%d"
-        if np.issubdtype(value.dtype, np.integer)
-        else "%.9e"
-        if np.issubdtype(value.dtype, np.floating)
-        else "%s"
-    )
+
+    # Use precision from active context if available
+    if np.issubdtype(value.dtype, np.floating):
+        precision = 9  # default
+        if _ACTIVE_CONTEXT is not None:
+            precision = _ACTIVE_CONTEXT.float_precision
+        format = f"%.{precision}e"
+    elif np.issubdtype(value.dtype, np.integer):
+        format = "%d"
+    else:
+        format = "%s"
+
     np.savetxt(buffer, value, fmt=format, delimiter=" ")
     return buffer.getvalue().strip()
 

--- a/flopy4/mf6/codec/writer/templates/macros.jinja
+++ b/flopy4/mf6/codec/writer/templates/macros.jinja
@@ -32,23 +32,23 @@
 {{ inset ~ name.upper() }}{% if "layered" in how %} LAYERED{% endif %}
 
 {% if how == "constant" %}
-{{ inset }}CONSTANT {{ value|array2const }}
+{{ inset }}CONSTANT {{ value|array2const(context.float_precision) }}
 {% elif how == "layered constant" %}
 {% for layer in value -%}
-{{ "\n" ~ inset }}CONSTANT {{ layer|array2const }}
+{{ "\n" ~ inset }}CONSTANT {{ layer|array2const(context.float_precision) }}
 {%- endfor %}
 {% elif how == "layered internal" %}
 {% for layer in value %}
 
 {{ inset }}INTERNAL
 {% for chunk in layer|array2chunks -%}
-{{ (2 * inset) ~ chunk|array2string }}
+{{ (2 * inset) ~ chunk|array2string(context.float_precision) }}
 {%- endfor %}
 {%- endfor %}
 {% elif how == "internal" %}
 {{ inset }}INTERNAL
 {% for chunk in value|array2chunks -%}
-{{ (2 * inset) ~ chunk|array2string }}
+{{ (2 * inset) ~ chunk|array2string(context.float_precision) }}
 {%- endfor %}
 {% elif how == "external" %}
 OPEN/CLOSE {{ value }}

--- a/flopy4/mf6/component.py
+++ b/flopy4/mf6/component.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from collections.abc import MutableMapping
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Optional
 
 from attrs import fields
 from modflow_devtools.dfn import Dfn, Field
@@ -12,6 +12,7 @@ from xattree import xattree
 from flopy4.mf6.constants import MF6
 from flopy4.mf6.spec import field, fields_dict, to_field
 from flopy4.mf6.utils.grid import update_maxbound
+from flopy4.mf6.write_context import WriteContext
 from flopy4.uio import IO, Loader, Writer
 
 COMPONENTS = {}
@@ -38,6 +39,9 @@ class Component(ABC, MutableMapping):
 
     filename: str | None = field(default=None)
     """The name of the component's input file."""
+
+    write_context: Optional[WriteContext] = field(default=None, repr=False)
+    """Configuration context for writing input files."""
 
     @property
     def path(self) -> Path:
@@ -142,16 +146,32 @@ class Component(ABC, MutableMapping):
         for child in self.children.values():  # type: ignore
             child.load(format=format)
 
-    def write(self, format: str = MF6) -> None:
-        """Write the component and any children."""
+    def write(self, format: str = MF6, context: Optional[WriteContext] = None) -> None:
+        """
+        Write the component and any children.
+
+        Parameters
+        ----------
+        format : str, optional
+            Output format. Default is MF6.
+        context : WriteContext, optional
+            Configuration context for writing. If provided, overrides
+            the component's write_context. If neither is provided,
+            uses the current context from the context manager stack,
+            or default settings.
+        """
         # TODO: setting filename is a temp hack to get the parent's
         # name as this component's filename stem, if it has one. an
         # actual solution is to auto-set the filename when children
         # are attached to parents.
         self.filename = self.filename or self.default_filename()
-        self._write(format=format)
+
+        # Determine active context: provided > attached > current > default
+        active_context = context or self.write_context or WriteContext.current()
+
+        self._write(format=format, context=active_context)
         for child in self.children.values():  # type: ignore
-            child.write(format=format)
+            child.write(format=format, context=context)
 
     def to_dict(self, blocks: bool = False, strict: bool = False) -> dict[str, Any]:
         """

--- a/flopy4/mf6/component.py
+++ b/flopy4/mf6/component.py
@@ -40,9 +40,6 @@ class Component(ABC, MutableMapping):
     filename: str | None = field(default=None)
     """The name of the component's input file."""
 
-    write_context: Optional[WriteContext] = field(default=None, repr=False)
-    """Configuration context for writing input files."""
-
     @property
     def path(self) -> Path:
         """The path to the component's input file."""
@@ -155,8 +152,7 @@ class Component(ABC, MutableMapping):
         format : str, optional
             Output format. Default is MF6.
         context : WriteContext, optional
-            Configuration context for writing. If provided, overrides
-            the component's write_context. If neither is provided,
+            Configuration context for writing. If not provided,
             uses the current context from the context manager stack,
             or default settings.
         """
@@ -166,8 +162,8 @@ class Component(ABC, MutableMapping):
         # are attached to parents.
         self.filename = self.filename or self.default_filename()
 
-        # Determine active context: provided > attached > current > default
-        active_context = context or self.write_context or WriteContext.current()
+        # Determine active context: provided > current > default
+        active_context = context or WriteContext.current()
 
         self._write(format=format, context=active_context)
         for child in self.children.values():  # type: ignore

--- a/flopy4/mf6/context.py
+++ b/flopy4/mf6/context.py
@@ -52,9 +52,9 @@ class Context(Component, ABC):
         with cd(self.workspace):
             super().load(format=format)
 
-    def write(self, format=MF6):
+    def write(self, format=MF6, context=None):
         with cd(self.workspace):
-            super().write(format=format)
+            super().write(format=format, context=context)
 
     def to_xarray(self):
         return self.data  # type: ignore

--- a/flopy4/mf6/write_context.py
+++ b/flopy4/mf6/write_context.py
@@ -1,9 +1,12 @@
 """Write context for configuring MF6 input file writing."""
 
 import threading
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, ClassVar, Literal, Optional
 
 from attrs import define, field
+
+if TYPE_CHECKING:
+    from threading import local
 
 ArrayFormat = Literal["internal", "constant", "open/close"]
 
@@ -16,10 +19,9 @@ class WriteContext:
     This class controls how simulation data is written to input files,
     including numeric precision, binary vs ASCII format, and path handling.
 
-    Can be used in three ways:
-    1. Attached to a component: component.write_context = ctx
-    2. Passed to write method: component.write(context=ctx)
-    3. As a context manager for temporary configuration
+    Can be used in two ways:
+    1. Passed to write method: component.write(context=ctx)
+    2. As a context manager for temporary configuration
 
     Parameters
     ----------
@@ -30,7 +32,7 @@ class WriteContext:
         Arrays larger than this will be written as binary.
         If None, use_binary setting is used unconditionally.
     float_precision : int, optional
-        Number of decimal places for float output. Default is 6.
+        Number of decimal places for float output. Default is 8.
     use_relative_paths : bool, optional
         Use relative paths in input files. Default is True.
     array_format : ArrayFormat, optional
@@ -39,11 +41,6 @@ class WriteContext:
 
     Examples
     --------
-    >>> # Attach to component
-    >>> ctx = WriteContext(float_precision=8, use_binary=True)
-    >>> sim.write_context = ctx
-    >>> sim.write()
-
     >>> # Pass to write method
     >>> sim.write(context=WriteContext(float_precision=4))
 
@@ -54,24 +51,31 @@ class WriteContext:
 
     use_binary: bool = field(default=False)
     binary_threshold: Optional[int] = field(default=None)
-    float_precision: int = field(default=6)
+    float_precision: int = field(default=8)
     use_relative_paths: bool = field(default=True)
     array_format: Optional[ArrayFormat] = field(default=None)
 
     # Class-level thread-local storage for context stack
-    _context_stack: threading.local = field(init=False, factory=threading.local)
+    _global_context_stack: ClassVar["local"]
 
     def __enter__(self) -> "WriteContext":
         """Enter context manager, pushing this context onto the stack."""
-        if not hasattr(self._context_stack, "stack"):
-            self._context_stack.stack = []
-        self._context_stack.stack.append(self)
+        # Use class-level thread-local storage
+        if not hasattr(WriteContext, "_global_context_stack"):
+            WriteContext._global_context_stack = threading.local()
+        if not hasattr(WriteContext._global_context_stack, "stack"):
+            WriteContext._global_context_stack.stack = []
+        WriteContext._global_context_stack.stack.append(self)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """Exit context manager, popping this context from the stack."""
-        if hasattr(self._context_stack, "stack") and self._context_stack.stack:
-            self._context_stack.stack.pop()
+        if (
+            hasattr(WriteContext, "_global_context_stack")
+            and hasattr(WriteContext._global_context_stack, "stack")
+            and WriteContext._global_context_stack.stack
+        ):
+            WriteContext._global_context_stack.stack.pop()
 
     @classmethod
     def current(cls) -> "WriteContext":
@@ -90,10 +94,7 @@ class WriteContext:
         if not hasattr(cls, "_global_context_stack"):
             cls._global_context_stack = threading.local()
 
-        if (
-            hasattr(cls._global_context_stack, "stack")
-            and cls._global_context_stack.stack
-        ):
+        if hasattr(cls._global_context_stack, "stack") and cls._global_context_stack.stack:
             return cls._global_context_stack.stack[-1]
         return cls.default()
 

--- a/flopy4/mf6/write_context.py
+++ b/flopy4/mf6/write_context.py
@@ -1,0 +1,138 @@
+"""Write context for configuring MF6 input file writing."""
+
+import threading
+from typing import Literal, Optional
+
+from attrs import define, field
+
+ArrayFormat = Literal["internal", "constant", "open/close"]
+
+
+@define
+class WriteContext:
+    """
+    Configuration context for writing MODFLOW 6 input files.
+
+    This class controls how simulation data is written to input files,
+    including numeric precision, binary vs ASCII format, and path handling.
+
+    Can be used in three ways:
+    1. Attached to a component: component.write_context = ctx
+    2. Passed to write method: component.write(context=ctx)
+    3. As a context manager for temporary configuration
+
+    Parameters
+    ----------
+    use_binary : bool, optional
+        Prefer binary files for arrays. Default is False.
+    binary_threshold : int, optional
+        Size threshold (in bytes) for using binary format.
+        Arrays larger than this will be written as binary.
+        If None, use_binary setting is used unconditionally.
+    float_precision : int, optional
+        Number of decimal places for float output. Default is 6.
+    use_relative_paths : bool, optional
+        Use relative paths in input files. Default is True.
+    array_format : ArrayFormat, optional
+        How to write array data: 'internal', 'constant', or 'open/close'.
+        If None, automatically determined based on array properties.
+
+    Examples
+    --------
+    >>> # Attach to component
+    >>> ctx = WriteContext(float_precision=8, use_binary=True)
+    >>> sim.write_context = ctx
+    >>> sim.write()
+
+    >>> # Pass to write method
+    >>> sim.write(context=WriteContext(float_precision=4))
+
+    >>> # Use as context manager
+    >>> with WriteContext(use_binary=True, float_precision=8):
+    ...     sim.write()
+    """
+
+    use_binary: bool = field(default=False)
+    binary_threshold: Optional[int] = field(default=None)
+    float_precision: int = field(default=6)
+    use_relative_paths: bool = field(default=True)
+    array_format: Optional[ArrayFormat] = field(default=None)
+
+    # Class-level thread-local storage for context stack
+    _context_stack: threading.local = field(init=False, factory=threading.local)
+
+    def __enter__(self) -> "WriteContext":
+        """Enter context manager, pushing this context onto the stack."""
+        if not hasattr(self._context_stack, "stack"):
+            self._context_stack.stack = []
+        self._context_stack.stack.append(self)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Exit context manager, popping this context from the stack."""
+        if hasattr(self._context_stack, "stack") and self._context_stack.stack:
+            self._context_stack.stack.pop()
+
+    @classmethod
+    def current(cls) -> "WriteContext":
+        """
+        Get the currently active WriteContext from the context stack.
+
+        Returns the most recently entered context manager, or a default
+        context if no context manager is active.
+
+        Returns
+        -------
+        WriteContext
+            The active context, or a default context.
+        """
+        # Create a class-level thread-local if it doesn't exist
+        if not hasattr(cls, "_global_context_stack"):
+            cls._global_context_stack = threading.local()
+
+        if (
+            hasattr(cls._global_context_stack, "stack")
+            and cls._global_context_stack.stack
+        ):
+            return cls._global_context_stack.stack[-1]
+        return cls.default()
+
+    @classmethod
+    def default(cls) -> "WriteContext":
+        """
+        Create a WriteContext with default settings.
+
+        Returns
+        -------
+        WriteContext
+            A context with default configuration values.
+        """
+        return cls()
+
+    def to_numpy_printoptions(self) -> dict:
+        """
+        Convert WriteContext settings to numpy printoptions dict.
+
+        Returns
+        -------
+        dict
+            Dictionary suitable for use with np.printoptions()
+        """
+        import sys
+
+        return {
+            "precision": self.float_precision,
+            "linewidth": sys.maxsize,
+            "threshold": sys.maxsize,
+        }
+
+    def get_float_format(self) -> str:
+        """
+        Get the float format string based on precision setting.
+
+        Returns
+        -------
+        str
+            Format string for floating point numbers (e.g., "%.6e")
+        """
+        return f"%.{self.float_precision}e"

--- a/test/test_write_context.py
+++ b/test/test_write_context.py
@@ -1,0 +1,204 @@
+"""Tests for WriteContext functionality."""
+
+import threading
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from flopy4.mf6.gwf import Chd, Dis, Gwf, Ic, Npf, Oc
+from flopy4.mf6.ims import Ims
+from flopy4.mf6.simulation import Simulation
+from flopy4.mf6.utils.time import Time
+from flopy4.mf6.write_context import WriteContext
+
+
+def test_write_context_default():
+    """Test default WriteContext initialization."""
+    ctx = WriteContext()
+    assert ctx.use_binary is False
+    assert ctx.binary_threshold is None
+    assert ctx.float_precision == 6
+    assert ctx.use_relative_paths is True
+    assert ctx.array_format is None
+
+
+def test_write_context_custom():
+    """Test WriteContext with custom settings."""
+    ctx = WriteContext(
+        use_binary=True, float_precision=8, use_relative_paths=False
+    )
+    assert ctx.use_binary is True
+    assert ctx.float_precision == 8
+    assert ctx.use_relative_paths is False
+
+
+def test_write_context_to_numpy_printoptions():
+    """Test conversion to numpy printoptions."""
+    ctx = WriteContext(float_precision=4)
+    opts = ctx.to_numpy_printoptions()
+
+    assert opts["precision"] == 4
+    assert "linewidth" in opts
+    assert "threshold" in opts
+
+
+def test_write_context_get_float_format():
+    """Test float format string generation."""
+    ctx = WriteContext(float_precision=6)
+    assert ctx.get_float_format() == "%.6e"
+
+    ctx2 = WriteContext(float_precision=10)
+    assert ctx2.get_float_format() == "%.10e"
+
+
+def test_write_context_manager():
+    """Test WriteContext as context manager."""
+    # Default context
+    default_ctx = WriteContext.current()
+    assert default_ctx.float_precision == 6
+
+    # Enter context manager
+    with WriteContext(float_precision=8):
+        current = WriteContext.current()
+        assert current.float_precision == 8
+
+    # After exiting, should return to default
+    after = WriteContext.current()
+    assert after.float_precision == 6
+
+
+def test_write_context_manager_nesting():
+    """Test nested WriteContext managers."""
+    with WriteContext(float_precision=4):
+        assert WriteContext.current().float_precision == 4
+
+        with WriteContext(float_precision=8):
+            assert WriteContext.current().float_precision == 8
+
+        # Should return to outer context
+        assert WriteContext.current().float_precision == 4
+
+    # Should return to default
+    assert WriteContext.current().float_precision == 6
+
+
+def test_write_context_thread_local():
+    """Test that WriteContext is thread-local."""
+    results = {}
+
+    def thread_func(precision):
+        with WriteContext(float_precision=precision):
+            results[threading.current_thread().name] = (
+                WriteContext.current().float_precision
+            )
+
+    t1 = threading.Thread(target=thread_func, args=(4,), name="t1")
+    t2 = threading.Thread(target=thread_func, args=(8,), name="t2")
+
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert results["t1"] == 4
+    assert results["t2"] == 8
+
+
+def test_component_write_context_attribute(function_tmpdir):
+    """Test that components can have write_context attached."""
+    time = Time(perlen=[1.0], nstp=[1])
+    sim = Simulation(
+        name="test",
+        workspace=function_tmpdir,
+        tdis=time,
+    )
+
+    # Initially None
+    assert sim.write_context is None
+
+    # Can be set
+    ctx = WriteContext(float_precision=8)
+    sim.write_context = ctx
+    assert sim.write_context is ctx
+    assert sim.write_context.float_precision == 8
+
+
+def test_component_write_with_context(function_tmpdir):
+    """Test writing component with explicit context."""
+    time = Time(perlen=[1.0], nstp=[1])
+    ims = Ims(models=["gwf"])
+    dis = Dis(nlay=1, nrow=2, ncol=2, delr=1.0, delc=1.0, top=1.0, botm=0.0)
+
+    sim = Simulation(
+        name="test",
+        workspace=function_tmpdir,
+        tdis=time,
+        solutions={"ims": ims},
+    )
+
+    gwf = Gwf(parent=sim, name="gwf", dis=dis)
+    ic = Ic(parent=gwf, strt=1.0)
+    npf = Npf(parent=gwf, k=1.0)
+    chd = Chd(parent=gwf, head={0: {(0, 0, 0): 1.0}})
+    oc = Oc(parent=gwf, head_file="gwf.hds", budget_file="gwf.bud")
+
+    # Write with custom context
+    ctx = WriteContext(float_precision=8)
+    sim.write(context=ctx)
+
+    # Check that files were written
+    assert (function_tmpdir / "mfsim.nam").exists()
+    assert (function_tmpdir / "gwf.dis").exists()
+
+
+def test_component_write_with_attached_context(function_tmpdir):
+    """Test writing component with attached context."""
+    time = Time(perlen=[1.0], nstp=[1])
+    ims = Ims(models=["gwf"])
+    dis = Dis(nlay=1, nrow=2, ncol=2, delr=1.0, delc=1.0, top=1.0, botm=0.0)
+
+    sim = Simulation(
+        name="test",
+        workspace=function_tmpdir,
+        tdis=time,
+        solutions={"ims": ims},
+    )
+
+    gwf = Gwf(parent=sim, name="gwf", dis=dis)
+    ic = Ic(parent=gwf, strt=1.0)
+    npf = Npf(parent=gwf, k=1.0)
+
+    # Attach context to simulation
+    sim.write_context = WriteContext(float_precision=4)
+    sim.write()
+
+    # Check that files were written
+    assert (function_tmpdir / "mfsim.nam").exists()
+    assert (function_tmpdir / "gwf.dis").exists()
+
+
+def test_write_context_manager_with_component(function_tmpdir):
+    """Test using WriteContext as context manager with component write."""
+    time = Time(perlen=[1.0], nstp=[1])
+    ims = Ims(models=["gwf"])
+    dis = Dis(nlay=1, nrow=2, ncol=2, delr=1.0, delc=1.0, top=1.0, botm=0.0)
+
+    sim = Simulation(
+        name="test",
+        workspace=function_tmpdir,
+        tdis=time,
+        solutions={"ims": ims},
+    )
+
+    gwf = Gwf(parent=sim, name="gwf", dis=dis)
+    ic = Ic(parent=gwf, strt=1.0)
+    npf = Npf(parent=gwf, k=1.0)
+
+    # Use context manager
+    with WriteContext(float_precision=10):
+        sim.write()
+
+    # Check that files were written
+    assert (function_tmpdir / "mfsim.nam").exists()
+    assert (function_tmpdir / "gwf.dis").exists()

--- a/test/test_write_context.py
+++ b/test/test_write_context.py
@@ -149,3 +149,49 @@ def test_write_context_manager_with_component(function_tmpdir):
     # Check that files were written
     assert (function_tmpdir / "mfsim.nam").exists()
     assert (function_tmpdir / "gwf.dis").exists()
+
+
+def test_nested_write_context_precision(function_tmpdir):
+    """Test that nested WriteContext uses correct precision in actual writes."""
+
+    # Create component with a float value that will show precision differences
+    dis = Dis(
+        nlay=1,
+        nrow=1,
+        ncol=1,
+        delr=1.0,
+        delc=1.0,
+        top=1.123456789,  # Value with many decimals
+        botm=0.0,
+    )
+
+    # Outer context: precision=4
+    with WriteContext(float_precision=4):
+        outer_file = function_tmpdir / "outer.dis"
+        dis.filename = str(outer_file)
+        dis.write()
+        outer_content = outer_file.read_text()
+
+        # Inner nested context: precision=10
+        with WriteContext(float_precision=10):
+            inner_file = function_tmpdir / "inner.dis"
+            dis.filename = str(inner_file)
+            dis.write()
+            inner_content = inner_file.read_text()
+
+        # Back to outer context: precision=4
+        after_file = function_tmpdir / "after.dis"
+        dis.filename = str(after_file)
+        dis.write()
+        after_content = after_file.read_text()
+
+    # Verify precision is respected at each level
+    # Outer: 4 decimals
+    assert "1.1235" in outer_content  # Rounded to 4 decimals
+
+    # Inner: 10 decimals
+    assert "1.1234567890" in inner_content  # Full 10 decimals
+
+    # After: back to 4 decimals
+    assert "1.1235" in after_content
+    assert after_content == outer_content

--- a/test/test_write_context.py
+++ b/test/test_write_context.py
@@ -1,10 +1,6 @@
 """Tests for WriteContext functionality."""
 
 import threading
-from pathlib import Path
-
-import numpy as np
-import pytest
 
 from flopy4.mf6.gwf import Chd, Dis, Gwf, Ic, Npf, Oc
 from flopy4.mf6.ims import Ims
@@ -18,16 +14,14 @@ def test_write_context_default():
     ctx = WriteContext()
     assert ctx.use_binary is False
     assert ctx.binary_threshold is None
-    assert ctx.float_precision == 6
+    assert ctx.float_precision == 8
     assert ctx.use_relative_paths is True
     assert ctx.array_format is None
 
 
 def test_write_context_custom():
     """Test WriteContext with custom settings."""
-    ctx = WriteContext(
-        use_binary=True, float_precision=8, use_relative_paths=False
-    )
+    ctx = WriteContext(use_binary=True, float_precision=8, use_relative_paths=False)
     assert ctx.use_binary is True
     assert ctx.float_precision == 8
     assert ctx.use_relative_paths is False
@@ -56,16 +50,16 @@ def test_write_context_manager():
     """Test WriteContext as context manager."""
     # Default context
     default_ctx = WriteContext.current()
-    assert default_ctx.float_precision == 6
+    assert default_ctx.float_precision == 8
 
     # Enter context manager
-    with WriteContext(float_precision=8):
+    with WriteContext(float_precision=10):
         current = WriteContext.current()
-        assert current.float_precision == 8
+        assert current.float_precision == 10
 
     # After exiting, should return to default
     after = WriteContext.current()
-    assert after.float_precision == 6
+    assert after.float_precision == 8
 
 
 def test_write_context_manager_nesting():
@@ -73,14 +67,14 @@ def test_write_context_manager_nesting():
     with WriteContext(float_precision=4):
         assert WriteContext.current().float_precision == 4
 
-        with WriteContext(float_precision=8):
-            assert WriteContext.current().float_precision == 8
+        with WriteContext(float_precision=6):
+            assert WriteContext.current().float_precision == 6
 
         # Should return to outer context
         assert WriteContext.current().float_precision == 4
 
     # Should return to default
-    assert WriteContext.current().float_precision == 6
+    assert WriteContext.current().float_precision == 8
 
 
 def test_write_context_thread_local():
@@ -89,9 +83,7 @@ def test_write_context_thread_local():
 
     def thread_func(precision):
         with WriteContext(float_precision=precision):
-            results[threading.current_thread().name] = (
-                WriteContext.current().float_precision
-            )
+            results[threading.current_thread().name] = WriteContext.current().float_precision
 
     t1 = threading.Thread(target=thread_func, args=(4,), name="t1")
     t2 = threading.Thread(target=thread_func, args=(8,), name="t2")
@@ -103,25 +95,6 @@ def test_write_context_thread_local():
 
     assert results["t1"] == 4
     assert results["t2"] == 8
-
-
-def test_component_write_context_attribute(function_tmpdir):
-    """Test that components can have write_context attached."""
-    time = Time(perlen=[1.0], nstp=[1])
-    sim = Simulation(
-        name="test",
-        workspace=function_tmpdir,
-        tdis=time,
-    )
-
-    # Initially None
-    assert sim.write_context is None
-
-    # Can be set
-    ctx = WriteContext(float_precision=8)
-    sim.write_context = ctx
-    assert sim.write_context is ctx
-    assert sim.write_context.float_precision == 8
 
 
 def test_component_write_with_context(function_tmpdir):
@@ -146,32 +119,6 @@ def test_component_write_with_context(function_tmpdir):
     # Write with custom context
     ctx = WriteContext(float_precision=8)
     sim.write(context=ctx)
-
-    # Check that files were written
-    assert (function_tmpdir / "mfsim.nam").exists()
-    assert (function_tmpdir / "gwf.dis").exists()
-
-
-def test_component_write_with_attached_context(function_tmpdir):
-    """Test writing component with attached context."""
-    time = Time(perlen=[1.0], nstp=[1])
-    ims = Ims(models=["gwf"])
-    dis = Dis(nlay=1, nrow=2, ncol=2, delr=1.0, delc=1.0, top=1.0, botm=0.0)
-
-    sim = Simulation(
-        name="test",
-        workspace=function_tmpdir,
-        tdis=time,
-        solutions={"ims": ims},
-    )
-
-    gwf = Gwf(parent=sim, name="gwf", dis=dis)
-    ic = Ic(parent=gwf, strt=1.0)
-    npf = Npf(parent=gwf, k=1.0)
-
-    # Attach context to simulation
-    sim.write_context = WriteContext(float_precision=4)
-    sim.write()
 
     # Check that files were written
     assert (function_tmpdir / "mfsim.nam").exists()


### PR DESCRIPTION
First pass at #256. `WriteContext` class inspired by imod-python's, to control how MODFLOW 6 input files are written, including float precision, binary vs ASCII format, path handling, etc.

There are 2 usage patterns:

    1. Pass to `write()`: `sim.write(context=WriteContext(float_precision=4))`
    2. Context manager: `with WriteContext(float_precision=8): sim.write()`

Nested contexts are supported, with inner contexts overwriting settings from outer ones.
  
The context manager approach is thread-local so should support multi-threaded writing later on. Precision defaults to 8 decimal places to match the current default in the writer jinja filters.