### PR TITLE
fix(write): strip extra trailing newline

### DIFF
--- a/flopy4/mf6/codec/writer/__init__.py
+++ b/flopy4/mf6/codec/writer/__init__.py
@@ -45,8 +45,11 @@ def _clean_last_chunk(iterator: Iterator[str]) -> Iterator[str]:
         yield current_chunk
         current_chunk = next_chunk
 
-    # When for-loop ends, current_chunk is the last chunk which is "\n\n"
-    yield "\n"
+    # When for-loop ends, if current_chunk is "\n\n", strip one newline
+    if current_chunk == "\n\n":
+        yield "\n"
+    else:
+        yield current_chunk
 
 
 def dumps(data, context=None) -> str:

--- a/flopy4/mf6/codec/writer/__init__.py
+++ b/flopy4/mf6/codec/writer/__init__.py
@@ -1,5 +1,5 @@
 import sys
-from typing import IO
+from typing import IO, Iterator
 
 import numpy as np
 from jinja2 import Environment, PackageLoader
@@ -31,6 +31,22 @@ def _get_print_options(context=None):
         "linewidth": sys.maxsize,
         "threshold": sys.maxsize,
     }
+
+
+def _clean_last_chunk(iterator: Iterator[str]) -> Iterator[str]:
+    """Strip extra newline at the end of last chunk."""
+    try:
+        current_chunk = next(iterator)
+    except StopIteration:
+        return
+
+    # Look ahead to find last chunk
+    for next_chunk in iterator:
+        yield current_chunk
+        current_chunk = next_chunk
+
+    # When for-loop ends, current_chunk is the last chunk which is "\n\n"
+    yield "\n"
 
 
 def dumps(data, context=None) -> str:
@@ -84,4 +100,4 @@ def dump(data, fp: IO[str], context=None) -> None:
     iterator = template.generate(blocks=data, context=context)
     print_opts = _get_print_options(context)
     with np.printoptions(**print_opts):  # type: ignore
-        fp.writelines(iterator)
+        fp.writelines(_clean_last_chunk(iterator))

--- a/test/test_mf6_codec.py
+++ b/test/test_mf6_codec.py
@@ -5,7 +5,7 @@ from pprint import pprint
 import numpy as np
 import pytest
 
-from flopy4.mf6.codec import dumps, loads
+from flopy4.mf6.codec import dumps, loads, writer
 from flopy4.mf6.constants import FILL_DNODATA
 from flopy4.mf6.converter import COMPONENT_CONVERTER
 
@@ -637,3 +637,8 @@ def test_dumps_simulation():
     loaded = loads(dumped)
     print("Simulation load:")
     pprint(loaded)
+
+
+def test_clean_last_chunk():
+    cleaned = writer._clean_last_chunk(iter(["chunk1", "chunk2", "\n\n"]))
+    assert list(cleaned) == ["chunk1", "chunk2", "\n"]


### PR DESCRIPTION
This removes the extra trailing newline at the end of written MF6 input files following the Unix standard.