### PR TITLE
no dfn on class definitions

### DIFF
--- a/flopy4/mf6/component.py
+++ b/flopy4/mf6/component.py
@@ -2,16 +2,14 @@ from abc import ABC
 from collections.abc import MutableMapping
 from os import PathLike
 from pathlib import Path
-from typing import Any, ClassVar, Optional
+from typing import Any, Optional
 
 from attrs import fields
-from modflow_devtools.dfn import Dfn, Field
-from packaging.version import Version
 from xattree import asdict as xattree_asdict
 from xattree import xattree
 
 from flopy4.mf6.constants import MF6
-from flopy4.mf6.spec import field, fields_dict, to_field
+from flopy4.mf6.spec import field, fields_dict
 from flopy4.mf6.utils.grid import update_maxbound
 from flopy4.mf6.write_context import WriteContext
 from flopy4.uio import IO, Loader, Writer
@@ -34,9 +32,6 @@ class Component(ABC, MutableMapping):
 
     _load = IO(Loader)  # type: ignore
     _write = IO(Writer)  # type: ignore
-
-    dfn: ClassVar[Dfn]
-    """The component's definition (i.e. specification)."""
 
     filename: str | None = field(default=None)
     """The name of the component's input file."""
@@ -93,7 +88,6 @@ class Component(ABC, MutableMapping):
     @classmethod
     def __attrs_init_subclass__(cls):
         COMPONENTS[cls.__name__.lower()] = cls
-        cls.dfn = cls.get_dfn()
 
     def __getitem__(self, key):
         # We use `children` from `xattree` to implement MutableMapping.
@@ -112,26 +106,6 @@ class Component(ABC, MutableMapping):
 
     def __len__(self):
         return len(self.children)  # type: ignore
-
-    @classmethod
-    def get_dfn(cls) -> Dfn:
-        """Get the component's definition (i.e. specification)."""
-        fields = {field_name: to_field(field) for field_name, field in fields_dict(cls).items()}
-        blocks: dict[str, dict[str, Field]] = {}
-        for field_name, field_ in fields.items():
-            if (block := field_.block) is not None:
-                blocks.setdefault(block, {})[field_name] = field_
-            else:
-                blocks[field_name] = field_
-
-        return Dfn(
-            schema_version=Version("2"),
-            name=cls.__name__.lower(),
-            advanced=getattr(cls, "advanced_package", False),
-            multi=getattr(cls, "multi_package", False),
-            ref=getattr(cls, "sub_package", None),
-            blocks=blocks,
-        )
 
     @classmethod
     def load(cls, path: str | PathLike, format: str = MF6) -> None:
@@ -185,7 +159,7 @@ class Component(ABC, MutableMapping):
             in terms of fields (flat) or blocks (nested).
         """
         data = xattree_asdict(self)
-        spec = self.dfn.fields
+        spec = fields_dict(self.__class__)
 
         if strict:
             data.pop("filename")
@@ -193,9 +167,9 @@ class Component(ABC, MutableMapping):
 
         if blocks:
             blocks_ = {}  # type: ignore
-            for field_name in spec.keys():
+            for field_name, field_attr in spec.items():
                 field_value = data[field_name]
-                block_name = spec[field_name].block
+                block_name = field_attr.metadata.get("block")
                 if strict and block_name is None:
                     continue
                 if block_name not in blocks_:
@@ -205,8 +179,8 @@ class Component(ABC, MutableMapping):
         else:
             return {
                 field_name: data[field_name]
-                for field_name in spec.keys()
-                if spec[field_name].block or not strict
+                for field_name, field_attr in spec.items()
+                if field_attr.metadata.get("block") or not strict
             }
 
     def to_xarray(self):

--- a/flopy4/mf6/converter/egress/unstructure.py
+++ b/flopy4/mf6/converter/egress/unstructure.py
@@ -13,7 +13,7 @@ from flopy4.mf6.binding import Binding
 from flopy4.mf6.component import Component
 from flopy4.mf6.constants import FILL_DNODATA
 from flopy4.mf6.context import Context
-from flopy4.mf6.spec import FileInOut
+from flopy4.mf6.spec import FileInOut, blocks_dict
 
 
 def _path_to_tuple(name: str, value: Path, inout: FileInOut) -> tuple[str, ...]:
@@ -244,7 +244,7 @@ def unstructure_component(value: Component) -> dict[str, Any]:
 
 
 def _unstructure_array_component(value: Component) -> dict[str, Any]:
-    blockspec = dict(sorted(value.dfn.blocks.items(), key=block_sort_key))  # type: ignore
+    blockspec = blocks_dict(type(value))
     blocks: dict[str, dict[str, Any]] = {}
     xatspec = xattree.get_xatspec(type(value))
     data = xattree.asdict(value)
@@ -287,7 +287,7 @@ def _unstructure_array_component(value: Component) -> dict[str, Any]:
 
 
 def _unstructure_component(value: Component) -> dict[str, Any]:
-    blockspec = dict(sorted(value.dfn.blocks.items(), key=block_sort_key))  # type: ignore
+    blockspec = blocks_dict(type(value))
     blocks: dict[str, dict[str, Any]] = {}
     xatspec = xattree.get_xatspec(type(value))
     data = xattree.asdict(value)

--- a/flopy4/mf6/netcdf.py
+++ b/flopy4/mf6/netcdf.py
@@ -16,6 +16,7 @@ from xattree import XatSpec, asdict, get_xatspec
 from flopy4.mf6.constants import FILL_DNODATA, FILL_FLOAT64, FILL_INT64
 from flopy4.mf6.model import Model
 from flopy4.mf6.package import Package
+from flopy4.mf6.spec import blocks_dict
 from flopy4.mf6.utils.grid import StructuredGrid, VertexGrid
 from flopy4.mf6.utils.time import Time
 from flopy4.version import __version__
@@ -155,7 +156,7 @@ class NetCDFModel(BaseModel, NetCDFInput):
             multi = package.multi_package if hasattr(package, "multi_package") else False
             data = asdict(package)
 
-            for block_name, block in package.dfn.blocks.items():
+            for block_name, block in blocks_dict(type(package)).items():
                 if block_name != "griddata" and block_name != "period":
                     continue
                 for field_name in block.keys():

--- a/test/test_mf6_component.py
+++ b/test/test_mf6_component.py
@@ -330,54 +330,6 @@ def test_init_big_sim():
     assert "npf" not in gwf
 
 
-def test_gwf_dfn():
-    gwf = Gwf()
-    dfn = gwf.dfn
-    assert dfn.name == "gwf"
-    assert not dfn.advanced
-    assert not dfn.multi
-    assert dfn.ref is None
-    assert "save_flows" in set(dfn.blocks["options"].keys())
-
-
-def test_disv_dfn():
-    dims = {
-        "nlay": 1,
-        "nvert": 4,
-        "ncpl": 2,
-        "nodes": 2,
-    }
-    disv = Disv(dims=dims)
-    dfn = disv.dfn
-    assert dfn.name == "disv"
-    assert not dfn.advanced
-    assert not dfn.multi
-    assert dfn.ref is None
-    assert "nogrb" in set(dfn.blocks["options"].keys())
-
-
-def test_chd_dfn():
-    chd = Chd(strict=False)
-    dfn = chd.dfn
-    assert dfn.name == "chd"
-    assert not dfn.advanced
-    assert dfn.multi
-    assert dfn.ref is None
-    assert "print_input" in set(dfn.blocks["options"].keys())
-    assert "head" in set(dfn.blocks["period"].keys())
-
-
-def test_ims_dfn():
-    ims = Ims(strict=False)
-    dfn = ims.dfn
-    assert dfn.name == "ims"
-    assert not dfn.advanced
-    assert not dfn.multi
-    assert dfn.ref is None
-    assert "complexity" in set(dfn.blocks["options"].keys())
-    assert "inner_maximum" in set(dfn.blocks["linear"].keys())
-
-
 def test_write_ascii(function_tmpdir):
     sim_name = "sim"
     gwf_name = "gwf"


### PR DESCRIPTION
use the runtime spec as the single source of truth once we have generated code from DFNs, no juggling both anymore

close #290 