### PR TITLE
flesh out protocol impl

### DIFF
--- a/docs/dev/protocols-plan.md
+++ b/docs/dev/protocols-plan.md
@@ -127,25 +127,39 @@ For development/testing, provide an optional validation function:
   - Caching tests
   - All tests passing
 
-### Phase 3: Not Started
+### Phase 3: Complete ✅
 
-  **Integrate with _resolve_dimensions** - NOT DONE
-  - Update _resolve_dimensions() in structure.py:
-    - Try parent.get_all_dimensions() FIRST (new path)
-    - Fall back to xattree's parent.data.dims (compatibility)
-    - Keep computed dimension fallback (temporary)
-  - All tests pass using both new and fallback paths
-  - Tests: All existing tests pass (proving coexistence works)
+  **Integrate with _resolve_dimensions** - DONE ✅
+  - Updated _resolve_dimensions() in structure.py:
+    - Uses parent.resolve_dims() (new path)
+    - Removed xattree fallback - cleaner, simpler code
+  - Updated resolve_dims() to include parent dimensions (walks up hierarchy)
+  - Tests: All 207 non-integration tests pass
 
-  NOTE: structure.py has been created but still uses old xattree path (parent.data.dims)
+  **Validation** - DONE ✅
+  - Added conflict detection in resolve_dims()
+    - Detects conflicts among children at same level
+    - Allows children to override parent dimensions
+  - Added validate_dimension_resolution() validation tool in dimensions.py
 
-  **Validation** - NOT DONE
-  - Add conflict detection in get_all_dimensions()
-  - Add optional validate_dimension_resolution() tool
+  **Implement Disv DimensionProvider** - DONE ✅
+  - Added get_dims() to Disv class
+  - Returns nlay, ncpl, nvert, and computed nodes dimension
+  - All Disv-related tests now pass
+
+  **API Refinements** - DONE ✅
+  - Renamed: DimensionRegistry → DimensionResolver
+  - Renamed: DimensionRegistryMixin → DimensionResolverMixin
+  - Renamed: get_dimensions() → get_dims()
+  - Unified API: resolve_dimension() + get_all_dimensions() → resolve_dims()
+  - resolve_dims() always returns dict for consistency:
+    - `resolve_dims()` → all available dimensions
+    - `resolve_dims('nlay')` → `{'nlay': 3}`
+    - `resolve_dims('nlay', 'nrow')` → `{'nlay': 3, 'nrow': 10}`
 
   **ParentSettingDict** - NOT DONE
   - Not yet implemented
-  - Planned for Phase 3 (parent management migration)
+  - Deferred to Phase 4 (parent management migration)
 
 ### Phase 4: Future Work
 

--- a/flopy4/mf6/component.py
+++ b/flopy4/mf6/component.py
@@ -9,7 +9,7 @@ from xattree import asdict as xattree_asdict
 from xattree import xattree
 
 from flopy4.mf6.constants import MF6
-from flopy4.mf6.dimensions import DimensionRegistryMixin
+from flopy4.mf6.dimensions import DimensionResolverMixin
 from flopy4.mf6.spec import field, fields_dict
 from flopy4.mf6.utils.grid import update_maxbound
 from flopy4.mf6.write_context import WriteContext
@@ -22,7 +22,7 @@ COMPONENTS = {}
 # kw_only=True necessary so we can define optional fields here
 # and required fields in subclasses. attrs complains otherwise
 @xattree(kw_only=True)
-class Component(DimensionRegistryMixin, ABC, MutableMapping):
+class Component(DimensionResolverMixin, ABC, MutableMapping):
     """
     Base class for MF6 components.
 

--- a/flopy4/mf6/converter/ingress/structure.py
+++ b/flopy4/mf6/converter/ingress/structure.py
@@ -10,6 +10,7 @@ from xattree import get_xatspec
 from flopy4.adapters import get_nn
 from flopy4.mf6.config import SPARSE_THRESHOLD
 from flopy4.mf6.constants import FILL_DNODATA
+from flopy4.mf6.dimensions import DimensionResolver
 
 
 def structure_keyword(value, field) -> str | None:
@@ -48,7 +49,10 @@ def _resolve_dimensions(
 
     # Resolve dims from model context
     # Priority: 1) explicit dims parameter, 2) self_.__dict__, 3) parent
-    inherited_dims = dict(self_.parent.data.dims) if self_.parent else {}
+    inherited_dims = {}
+    if self_.parent and isinstance(self_.parent, DimensionResolver):
+        inherited_dims = self_.parent.resolve_dims()
+
     explicit_dims = self_.__dict__.get("dims", {})
     dim_dict = inherited_dims | explicit_dims
 

--- a/flopy4/mf6/dimensions.py
+++ b/flopy4/mf6/dimensions.py
@@ -17,7 +17,7 @@ class DimensionProvider(Protocol):
     Its consumers resolve dimensions by walking the object graph.
     """
 
-    def get_dimensions(self) -> dict[str, int]:
+    def get_dims(self) -> dict[str, int]:
         """
         Return dimension sizes.
 
@@ -32,13 +32,14 @@ class DimensionProvider(Protocol):
         Examples
         --------
         >>> dis = Dis(nlay=3, nrow=10, ncol=20)
-        >>> dis.get_dimensions()
+        >>> dis.get_dims()
         {'nlay': 3, 'nrow': 10, 'ncol': 20, 'nodes': 600, 'ncpl': 200}
         """
         ...
 
 
-class DimensionRegistry(Protocol):
+@runtime_checkable
+class DimensionResolver(Protocol):
     """
     Implement this protocol to participate in dimension resolution
     as a consumer.
@@ -46,9 +47,9 @@ class DimensionRegistry(Protocol):
     For components that consume dimensions from provider components.
     """
 
-    def resolve_dimension(self, dim_name: str) -> int | None:
+    def resolve_dims(self, *dims: str) -> dict[str, int]:
         """
-        Resolve dimension by lazily walking the object graph.
+        Resolve one or more dimensions by walking the object graph.
 
         Walk the current component's children looking for dimension
         providers. Dimensions not found are sought in the parent.
@@ -56,13 +57,15 @@ class DimensionRegistry(Protocol):
 
         Parameters
         ----------
-        dim_name : str
-            Name of the dimension to resolve.
+        *dims : str
+            Dimension names to resolve. If not provided, resolves all
+            available dimensions.
 
         Returns
         -------
-        int | None
-            The dimension value if found, None otherwise.
+        dict[str, int]
+            Dictionary mapping dimension names to their values. Only includes
+            dimensions that were found (requested dims that don't exist are omitted).
 
         Notes
         -----
@@ -75,32 +78,19 @@ class DimensionRegistry(Protocol):
         Examples
         --------
         >>> gwf = Gwf(dis=Dis(nlay=3, nrow=10, ncol=20))
-        >>> gwf.resolve_dimension('nlay')
-        3
-        >>> gwf.resolve_dimension('nonexistent')
-        None
-        """
-        ...
-
-    def get_all_dimensions(self) -> dict[str, int]:
-        """
-        Get all dimensions.
-
-        Returns
-        -------
-        dict[str, int]
-            Mapping of all dimensions
-
-        Examples
-        --------
-        >>> gwf = Gwf(dis=Dis(nlay=3, nrow=10, ncol=20))
-        >>> gwf.get_all_dimensions()
+        >>> gwf.resolve_dims()
         {'nlay': 3, 'nrow': 10, 'ncol': 20, 'nodes': 600, 'ncpl': 200}
+        >>> gwf.resolve_dims('nlay')
+        {'nlay': 3}
+        >>> gwf.resolve_dims('nlay', 'nrow')
+        {'nlay': 3, 'nrow': 10}
+        >>> gwf.resolve_dims('nonexistent')
+        {}
         """
         ...
 
 
-class DimensionRegistryMixin:
+class DimensionResolverMixin:
     """
     Mixin for components which consume dimensions from providers.
 
@@ -157,9 +147,9 @@ class DimensionRegistryMixin:
         #             if hasattr(child, 'parent'):
         #                 child.parent = self
 
-    def resolve_dimension(self, dim_name: str) -> int | None:
+    def resolve_dims(self, *dims: str) -> dict[str, int]:
         """
-        Resolve dimension by walking current object graph.
+        Resolve one or more dimensions by walking the object graph.
 
         This method implements lazy dimension resolution with caching. It first
         checks the cache, then walks children looking for dimension providers,
@@ -167,46 +157,64 @@ class DimensionRegistryMixin:
 
         Parameters
         ----------
-        dim_name : str
-            Name of the dimension to resolve.
+        *dims : str
+            Dimension names to resolve. If not provided, resolves all
+            available dimensions.
 
         Returns
         -------
-        int | None
-            The dimension value if found, None otherwise.
+        dict[str, int]
+            Dictionary mapping dimension names to their values. Only includes
+            dimensions that were found (requested dims that don't exist are omitted).
 
         Notes
         -----
         Resolution order:
         1. Check cache
         2. Walk fields looking for DimensionProviders
-        3. Check each provider's get_dimensions()
+        3. Check each provider's dims()
         4. If not found, delegate to parent
         5. Cache result
 
         Examples
         --------
-        >>> mixin = DimensionRegistryMixin()
-        >>> mixin.resolve_dimension('nlay')  # doctest: +SKIP
-        3
+        >>> mixin = DimensionResolverMixin()
+        >>> mixin.resolve_dims()  # doctest: +SKIP
+        {'nlay': 3, 'nrow': 10, 'ncol': 20}
+        >>> mixin.resolve_dims('nlay')  # doctest: +SKIP
+        {'nlay': 3}
+        >>> mixin.resolve_dims('nlay', 'nrow')  # doctest: +SKIP
+        {'nlay': 3, 'nrow': 10}
         """
-        result = self._dimension_cache.get(dim_name)
-        if result is not None:
-            return result
+        # No args: return all dimensions
+        if not dims:
+            return self._get_all_dimensions()
 
-        result = self._find_dimension_in_children(dim_name)
-        if result is not None:
-            self._dimension_cache[dim_name] = result
-            return result
+        # One or more args: return dict of found dimensions
+        result_dict = {}
+        for dim_name in dims:
+            # Check cache
+            if dim_name in self._dimension_cache:
+                result_dict[dim_name] = self._dimension_cache[dim_name]
+                continue
 
-        if hasattr(self, "parent") and self.parent is not None:
-            if hasattr(self.parent, "resolve_dimension"):
-                result = self.parent.resolve_dimension(dim_name)
-                if result is not None:
-                    self._dimension_cache[dim_name] = result
-                return result
+            # Find in children
+            value = self._find_dimension_in_children(dim_name)
+            if value is not None:
+                self._dimension_cache[dim_name] = value
+                result_dict[dim_name] = value
+                continue
 
-        return None
+            # Check parent
+            if hasattr(self, "parent") and self.parent is not None:
+                if hasattr(self.parent, "resolve_dims"):
+                    parent_result = self.parent.resolve_dims(dim_name)
+                    if dim_name in parent_result:
+                        value = parent_result[dim_name]
+                        self._dimension_cache[dim_name] = value
+                        result_dict[dim_name] = value
+
+        return result_dict
 
     def _find_dimension_in_children(self, dim_name: str) -> int | None:
         """Walk fields and check dimension providers for the requested dimension.
@@ -225,53 +233,207 @@ class DimensionRegistryMixin:
             if (value := getattr(self, field_obj.name, None)) is None:
                 continue
             if isinstance(value, DimensionProvider):
-                dims = value.get_dimensions()
-                if dim_name in dims:
-                    return dims[dim_name]
+                provider_dims = value.get_dims()
+                if dim_name in provider_dims:
+                    return provider_dims[dim_name]
             elif isinstance(value, dict):
                 for child in value.values():
                     if isinstance(child, DimensionProvider):
-                        dims = child.get_dimensions()
-                        if dim_name in dims:
-                            return dims[dim_name]
+                        provider_dims = child.get_dims()
+                        if dim_name in provider_dims:
+                            return provider_dims[dim_name]
             elif isinstance(value, list):
                 for child in value:
                     if isinstance(child, DimensionProvider):
-                        dims = child.get_dimensions()
-                        if dim_name in dims:
-                            return dims[dim_name]
+                        provider_dims = child.get_dims()
+                        if dim_name in provider_dims:
+                            return provider_dims[dim_name]
 
         return None
 
-    def get_all_dimensions(self) -> dict[str, int]:
+    def _get_all_dimensions(self) -> dict[str, int]:
         """
-        Get all dimensions.
+        Get all dimensions available to this component.
+
+        This includes dimensions from both children (dimension providers) and
+        the parent chain. Dimensions from children take precedence over parent
+        dimensions.
+
+        Raises
+        ------
+        ValueError
+            If multiple providers declare the same dimensions (conflict detected)
 
         Returns
         -------
         dict[str, int]
             Mapping of all dimensions
-
-        Examples
-        --------
-        >>> mixin = DimensionRegistryMixin()
-        >>> mixin.get_all_dimensions()  # doctest: +SKIP
-        {'nlay': 3, 'nrow': 10, 'ncol': 20}
         """
-        dims = {}
+        resolved_dims = {}
+        # Track which field provides which dimensions for conflict detection
+        dim_sources: dict[str, str] = {}
+
+        # First get dimensions from parent (lower priority)
+        if hasattr(self, "parent") and self.parent is not None:
+            if hasattr(self.parent, "resolve_dims"):
+                parent_dims = self.parent.resolve_dims()
+                resolved_dims.update(parent_dims)
+                for dim_name in parent_dims:
+                    dim_sources[dim_name] = "parent"
+
+        # Track dimensions from children separately to detect conflicts
+        child_dims: dict[str, int] = {}
 
         for field_obj in attrs.fields(type(self)):  # type: ignore[arg-type]
             if (value := getattr(self, field_obj.name, None)) is None:
                 continue
             if isinstance(value, DimensionProvider):
-                dims.update(value.get_dimensions())
+                provider_dims = value.get_dims()
+                # Check for conflicts with other children
+                # (not with parent - that's an override)
+                conflicts = set(provider_dims.keys()) & set(child_dims.keys())
+                if conflicts:
+                    conflict_sources = {
+                        dim: dim_sources[dim] for dim in conflicts if dim_sources[dim] != "parent"
+                    }
+                    raise ValueError(
+                        f"{type(self).__name__} has multiple providers "
+                        f"for dimensions: {conflicts}.\n"
+                        f"Field '{field_obj.name}' provides {set(provider_dims.keys())}, "
+                        f"already provided by {conflict_sources}"
+                    )
+                child_dims.update(provider_dims)
+                resolved_dims.update(provider_dims)  # Override parent dims if present
+                for dim_name in provider_dims:
+                    dim_sources[dim_name] = field_obj.name
             elif isinstance(value, dict):
-                for child in value.values():
+                for child_key, child in value.items():
                     if isinstance(child, DimensionProvider):
-                        dims.update(child.get_dimensions())
+                        provider_dims = child.get_dims()
+                        # Check for conflicts with other children
+                        # (not with parent - that's an override)
+                        conflicts = set(provider_dims.keys()) & set(child_dims.keys())
+                        if conflicts:
+                            conflict_sources = {
+                                dim: dim_sources[dim]
+                                for dim in conflicts
+                                if dim_sources[dim] != "parent"
+                            }
+                            raise ValueError(
+                                f"{type(self).__name__} has multiple providers "
+                                f"for dimensions: {conflicts}.\n"
+                                f"Dict field '{field_obj.name}[{child_key}]' provides "
+                                f"{set(provider_dims.keys())}, "
+                                f"already provided by {conflict_sources}"
+                            )
+                        child_dims.update(provider_dims)
+                        resolved_dims.update(provider_dims)  # Override parent dims if present
+                        for dim_name in provider_dims:
+                            dim_sources[dim_name] = f"{field_obj.name}[{child_key}]"
             elif isinstance(value, list):
-                for child in value:
+                for idx, child in enumerate(value):
                     if isinstance(child, DimensionProvider):
-                        dims.update(child.get_dimensions())
+                        provider_dims = child.get_dims()
+                        # Check for conflicts with other children
+                        # (not with parent - that's an override)
+                        conflicts = set(provider_dims.keys()) & set(child_dims.keys())
+                        if conflicts:
+                            conflict_sources = {
+                                dim: dim_sources[dim]
+                                for dim in conflicts
+                                if dim_sources[dim] != "parent"
+                            }
+                            raise ValueError(
+                                f"{type(self).__name__} has multiple providers "
+                                f"for dimensions: {conflicts}.\n"
+                                f"List field '{field_obj.name}[{idx}]' provides "
+                                f"{set(provider_dims.keys())}, "
+                                f"already provided by {conflict_sources}"
+                            )
+                        child_dims.update(provider_dims)
+                        resolved_dims.update(provider_dims)  # Override parent dims if present
+                        for dim_name in provider_dims:
+                            dim_sources[dim_name] = f"{field_obj.name}[{idx}]"
 
-        return dims
+        return resolved_dims
+
+
+def validate_dimension_resolution(component) -> list[str]:
+    """
+    Validate that all array fields can resolve their required dimensions.
+
+    This function walks the component hierarchy and checks that every array field
+    with dimension requirements can resolve those dimensions from the parent chain.
+    Use this in tests or CI to catch missing dimension providers.
+
+    Parameters
+    ----------
+    component : Component
+        The component to validate (must have DimensionResolver interface)
+
+    Returns
+    -------
+    list[str]
+        List of error messages for dimensions that cannot be resolved.
+        Empty list means all dimensions can be resolved successfully.
+
+    Examples
+    --------
+    >>> errors = validate_dimension_resolution(simulation)
+    >>> if errors:
+    ...     for error in errors:
+    ...         print(error)
+    >>> # Use in tests:
+    >>> assert not validate_dimension_resolution(sim), "Dimension resolution failed"
+    """
+    errors = []
+
+    # Check all array fields on this component
+    for field in attrs.fields(type(component)):
+        # Check if field has dimension metadata
+        if hasattr(field, "metadata") and field.metadata and "dims" in field.metadata:
+            dims_needed = field.metadata["dims"]
+            # Check if this component has a parent and can resolve dimensions
+            if hasattr(component, "parent") and component.parent:
+                if hasattr(component.parent, "resolve_dims"):
+                    for dim in dims_needed:
+                        result = component.parent.resolve_dims(dim)
+                        if dim not in result:
+                            errors.append(
+                                f"{type(component).__name__}.{field.name} needs dimension '{dim}' "
+                                f"but it's not available in parent hierarchy"
+                            )
+
+    # Recursively validate children
+    for field in attrs.fields(type(component)):
+        value = getattr(component, field.name, None)
+        if value is None:
+            continue
+
+        # Check if child is a component with attrs fields
+        if hasattr(value, "__class__") and hasattr(attrs, "fields"):
+            try:
+                attrs.fields(type(value))
+                # It's an attrs class, validate it
+                errors.extend(validate_dimension_resolution(value))
+            except Exception:
+                # Not an attrs class, skip
+                pass
+        elif isinstance(value, dict):
+            for child in value.values():
+                if hasattr(child, "__class__") and hasattr(attrs, "fields"):
+                    try:
+                        attrs.fields(type(child))
+                        errors.extend(validate_dimension_resolution(child))
+                    except Exception:
+                        pass
+        elif isinstance(value, list):
+            for child in value:
+                if hasattr(child, "__class__") and hasattr(attrs, "fields"):
+                    try:
+                        attrs.fields(type(child))
+                        errors.extend(validate_dimension_resolution(child))
+                    except Exception:
+                        pass
+
+    return errors

--- a/flopy4/mf6/gwf/dis.py
+++ b/flopy4/mf6/gwf/dis.py
@@ -119,7 +119,7 @@ class Dis(DisBase):
         self.nvert = (self.ncol + 1) * (self.nrow + 1)
         super().__attrs_post_init__()
 
-    def get_dimensions(self) -> dict[str, int]:
+    def get_dims(self) -> dict[str, int]:
         """Get all dimensions.
 
         Returns both explicit dimensions (nlay, nrow, ncol) and computed

--- a/flopy4/mf6/gwf/disv.py
+++ b/flopy4/mf6/gwf/disv.py
@@ -131,6 +131,24 @@ class Disv(DisBase):
         self.nrow = 0
         super().__attrs_post_init__()
 
+    def get_dims(self) -> dict[str, int]:
+        """Get all dimensions.
+
+        Returns both explicit dimensions (nlay, ncpl, nvert) and computed
+        dimensions (nodes).
+
+        Returns
+        -------
+        dict[str, int]
+            Mapping of dimension names to their integer sizes.
+        """
+        return {
+            "nlay": self.nlay,
+            "ncpl": self.ncpl,
+            "nvert": self.nvert,
+            "nodes": self.nlay * self.ncpl,
+        }
+
     def to_grid(self) -> VertexGrid:
         """
         Convert the discretization to a `VertexGrid`.

--- a/flopy4/mf6/tdis.py
+++ b/flopy4/mf6/tdis.py
@@ -42,7 +42,7 @@ class Tdis(Package):
         converter=Converter(structure_array, takes_self=True, takes_field=True),
     )
 
-    def get_dimensions(self) -> dict[str, int]:
+    def get_dims(self) -> dict[str, int]:
         """Get all dimensions.
 
         Returns

--- a/test/test_mf6_dimensions.py
+++ b/test/test_mf6_dimensions.py
@@ -5,7 +5,7 @@ from typing import Optional
 from attrs import field
 from xattree import xattree
 
-from flopy4.mf6.dimensions import DimensionRegistryMixin
+from flopy4.mf6.dimensions import DimensionResolverMixin
 
 # Test fixtures: simple test components
 
@@ -18,7 +18,7 @@ class MockDimensionProvider:
     nrow: int
     ncol: int
 
-    def get_dimensions(self) -> dict[str, int]:
+    def get_dims(self) -> dict[str, int]:
         """Return dimensions including computed ones."""
         return {
             "nlay": self.nlay,
@@ -30,7 +30,7 @@ class MockDimensionProvider:
 
 
 @xattree
-class MockContainer(DimensionRegistryMixin):
+class MockContainer(DimensionResolverMixin):
     """Mock container that uses the dimension registry mixin."""
 
     provider: Optional[MockDimensionProvider] = None
@@ -38,7 +38,7 @@ class MockContainer(DimensionRegistryMixin):
 
 
 @xattree
-class MockContainerWithDict(DimensionRegistryMixin):
+class MockContainerWithDict(DimensionResolverMixin):
     """Mock container with dict of providers."""
 
     providers: dict[str, MockDimensionProvider] = field(factory=dict)
@@ -46,58 +46,115 @@ class MockContainerWithDict(DimensionRegistryMixin):
 
 
 @xattree
-class MockContainerWithList(DimensionRegistryMixin):
+class MockContainerWithList(DimensionResolverMixin):
     """Mock container with list of providers."""
 
     providers: list[MockDimensionProvider] = field(factory=list)
     # parent is managed by xattree automatically
 
 
-# Tests for DimensionRegistryMixin
+# Tests for DimensionResolverMixin
 
 
-class TestDimensionRegistryMixin:
-    """Tests for DimensionRegistryMixin functionality."""
+class TestDimensionResolverMixin:
+    """Tests for DimensionResolverMixin functionality."""
 
     def test_resolve_dimension_from_direct_child(self):
         """Test resolving dimension from a direct child provider."""
         provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
         container = MockContainer(provider=provider)
 
-        assert container.resolve_dimension("nlay") == 3
-        assert container.resolve_dimension("nrow") == 10
-        assert container.resolve_dimension("ncol") == 20
+        assert container.resolve_dims("nlay") == {"nlay": 3}
+        assert container.resolve_dims("nrow") == {"nrow": 10}
+        assert container.resolve_dims("ncol") == {"ncol": 20}
 
     def test_resolve_computed_dimension(self):
         """Test resolving computed dimensions."""
         provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
         container = MockContainer(provider=provider)
 
-        assert container.resolve_dimension("nodes") == 600
-        assert container.resolve_dimension("ncpl") == 200
+        assert container.resolve_dims("nodes") == {"nodes": 600}
+        assert container.resolve_dims("ncpl") == {"ncpl": 200}
 
     def test_resolve_dimension_not_found(self):
         """Test resolving dimension that doesn't exist returns None."""
         provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
         container = MockContainer(provider=provider)
 
-        assert container.resolve_dimension("nonexistent") is None
+        assert container.resolve_dims("nonexistent") == {}
 
     def test_resolve_dimension_from_dict_child(self):
         """Test resolving dimension from children in a dict."""
         provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
         container = MockContainerWithDict(providers={"dis": provider})
 
-        assert container.resolve_dimension("nlay") == 3
-        assert container.resolve_dimension("nodes") == 600
+        assert container.resolve_dims("nlay") == {"nlay": 3}
+        assert container.resolve_dims("nodes") == {"nodes": 600}
 
     def test_resolve_dimension_from_list_child(self):
         """Test resolving dimension from children in a list."""
         provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
         container = MockContainerWithList(providers=[provider])
 
-        assert container.resolve_dimension("nlay") == 3
-        assert container.resolve_dimension("nodes") == 600
+        assert container.resolve_dims("nlay") == {"nlay": 3}
+        assert container.resolve_dims("nodes") == {"nodes": 600}
+
+    def test_resolve_multiple_dimensions(self):
+        """Test resolving multiple dimensions at once."""
+        provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
+        container = MockContainer(provider=provider)
+
+        # Request multiple dimensions
+        result = container.resolve_dims("nlay", "nrow", "ncol")
+        assert result == {"nlay": 3, "nrow": 10, "ncol": 20}
+
+    def test_resolve_multiple_with_computed(self):
+        """Test resolving multiple dimensions including computed ones."""
+        provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
+        container = MockContainer(provider=provider)
+
+        # Request mix of explicit and computed dimensions
+        result = container.resolve_dims("nlay", "nodes", "ncpl")
+        assert result == {"nlay": 3, "nodes": 600, "ncpl": 200}
+
+    def test_resolve_multiple_computed_dimensions(self):
+        """Test resolving only computed dimensions."""
+        provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
+        container = MockContainer(provider=provider)
+
+        # Request only computed dimensions
+        result = container.resolve_dims("nodes", "ncpl")
+        assert result == {"nodes": 600, "ncpl": 200}
+
+    def test_resolve_multiple_mix_valid_invalid(self):
+        """Test resolving mix of valid and invalid dimensions."""
+        provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
+        container = MockContainer(provider=provider)
+
+        # Request mix of valid and nonexistent dimensions
+        result = container.resolve_dims("nlay", "nonexistent", "nrow")
+        # Should only return the valid ones
+        assert result == {"nlay": 3, "nrow": 10}
+        assert "nonexistent" not in result
+
+    def test_resolve_multiple_all_invalid(self):
+        """Test resolving multiple dimensions that all don't exist."""
+        provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
+        container = MockContainer(provider=provider)
+
+        # Request only nonexistent dimensions
+        result = container.resolve_dims("invalid1", "invalid2", "invalid3")
+        assert result == {}
+
+    def test_resolve_duplicate_dimensions(self):
+        """Test resolving with duplicate dimension names."""
+        provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
+        container = MockContainer(provider=provider)
+
+        # Request same dimension multiple times
+        result = container.resolve_dims("nlay", "nlay", "nlay")
+        # Should handle duplicates gracefully and return it once
+        assert result == {"nlay": 3}
 
     def test_resolve_dimension_caching(self):
         """Test that resolved dimensions are cached."""
@@ -105,21 +162,37 @@ class TestDimensionRegistryMixin:
         container = MockContainer(provider=provider)
 
         # First resolution
-        result1 = container.resolve_dimension("nlay")
+        result1 = container.resolve_dims("nlay")
         # Check cache was populated
         assert "nlay" in container._dimension_cache
         assert container._dimension_cache["nlay"] == 3
 
         # Second resolution should use cache
-        result2 = container.resolve_dimension("nlay")
-        assert result1 == result2 == 3
+        result2 = container.resolve_dims("nlay")
+        assert result1 == result2 == {"nlay": 3}
+
+    def test_resolve_multiple_dimensions_uses_cache(self):
+        """Test that cache is used when resolving multiple dimensions."""
+        provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
+        container = MockContainer(provider=provider)
+
+        # First, resolve one dimension to populate cache
+        container.resolve_dims("nlay")
+        assert "nlay" in container._dimension_cache
+
+        # Now resolve multiple including the cached one
+        result = container.resolve_dims("nlay", "nrow")
+        assert result == {"nlay": 3, "nrow": 10}
+        # Both should now be cached
+        assert "nlay" in container._dimension_cache
+        assert "nrow" in container._dimension_cache
 
     def test_get_all_dimensions_direct_child(self):
         """Test getting all dimensions from direct child."""
         provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
         container = MockContainer(provider=provider)
 
-        dims = container.get_all_dimensions()
+        dims = container.resolve_dims()
         assert dims == {
             "nlay": 3,
             "nrow": 10,
@@ -133,7 +206,7 @@ class TestDimensionRegistryMixin:
         provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
         container = MockContainerWithDict(providers={"dis": provider})
 
-        dims = container.get_all_dimensions()
+        dims = container.resolve_dims()
         assert dims == {
             "nlay": 3,
             "nrow": 10,
@@ -147,7 +220,7 @@ class TestDimensionRegistryMixin:
         provider = MockDimensionProvider(nlay=3, nrow=10, ncol=20)
         container = MockContainerWithList(providers=[provider])
 
-        dims = container.get_all_dimensions()
+        dims = container.resolve_dims()
         assert dims == {
             "nlay": 3,
             "nrow": 10,
@@ -160,12 +233,12 @@ class TestDimensionRegistryMixin:
         """Test that None fields don't break dimension collection."""
         container = MockContainer(provider=None)
 
-        dims = container.get_all_dimensions()
+        dims = container.resolve_dims()
         assert dims == {}
 
 
 class TestDisDimensionProvider:
-    """Tests for Dis.get_dimensions() implementation."""
+    """Tests for Dis.get_dims() implementation."""
 
     def test_dis_get_dimensions(self):
         """Test that Dis returns all expected dimensions."""
@@ -173,7 +246,7 @@ class TestDisDimensionProvider:
 
         dis = Dis(nlay=3, nrow=10, ncol=20)
 
-        dims = dis.get_dimensions()
+        dims = dis.get_dims()
 
         assert dims == {
             "nlay": 3,
@@ -189,7 +262,7 @@ class TestDisDimensionProvider:
 
         dis = Dis(nlay=5, nrow=15, ncol=25)
 
-        dims = dis.get_dimensions()
+        dims = dis.get_dims()
 
         assert dims["nodes"] == 5 * 15 * 25
         assert dims["ncpl"] == 15 * 25
@@ -200,7 +273,7 @@ class TestDisDimensionProvider:
 
         dis = Dis(nlay=1, nrow=10, ncol=10)
 
-        dims = dis.get_dimensions()
+        dims = dis.get_dims()
 
         assert dims["nlay"] == 1
         assert dims["nodes"] == 100
@@ -208,7 +281,7 @@ class TestDisDimensionProvider:
 
 
 class TestTdisDimensionProvider:
-    """Tests for Tdis.get_dimensions() implementation."""
+    """Tests for Tdis.get_dims() implementation."""
 
     def test_tdis_get_dimensions(self):
         """Test that Tdis returns nper dimension."""
@@ -216,7 +289,7 @@ class TestTdisDimensionProvider:
 
         tdis = Tdis(nper=5)
 
-        dims = tdis.get_dimensions()
+        dims = tdis.get_dims()
 
         assert dims == {"nper": 5}
 
@@ -226,7 +299,7 @@ class TestTdisDimensionProvider:
 
         tdis = Tdis(nper=1)
 
-        dims = tdis.get_dimensions()
+        dims = tdis.get_dims()
 
         assert dims["nper"] == 1
 
@@ -236,7 +309,7 @@ class TestTdisDimensionProvider:
 
         tdis = Tdis(nper=100)
 
-        dims = tdis.get_dimensions()
+        dims = tdis.get_dims()
 
         assert dims["nper"] == 100
 
@@ -250,15 +323,15 @@ class TestComponentIntegration:
 
         dis = Dis(nlay=3, nrow=10, ncol=20)
 
-        # Component should have these methods from DimensionRegistryMixin
-        assert hasattr(dis, "resolve_dimension")
-        assert hasattr(dis, "get_all_dimensions")
+        # Component should have these methods from DimensionResolverMixin
+        assert hasattr(dis, "resolve_dims")
+        assert hasattr(dis, "get_dims")
 
         # Test that the methods actually work
-        # Dis doesn't have a parent, so resolve_dimension should return None for non-existent dims
-        assert dis.resolve_dimension("nonexistent") is None
+        # Dis doesn't have a parent, so resolve_dims should return {} for non-existent dims
+        assert dis.resolve_dims("nonexistent") == {}
         # get_all_dimensions should work since Dis is a DimensionProvider
-        dims = dis.get_dimensions()  # Dis is a provider, not a registry in this context
+        dims = dis.get_dims()  # Dis is a provider, not a registry in this context
         assert "nlay" in dims
         assert dims["nlay"] == 3
 
@@ -271,21 +344,21 @@ class TestComponentIntegration:
         gwf = Gwf(name="test", dis=dis)
 
         # Gwf should be able to get dimensions from its Dis child
-        assert gwf.resolve_dimension("nlay") == 3
-        assert gwf.resolve_dimension("nrow") == 10
-        assert gwf.resolve_dimension("ncol") == 20
-        assert gwf.resolve_dimension("nodes") == 600
-        assert gwf.resolve_dimension("ncpl") == 200
+        assert gwf.resolve_dims("nlay") == {"nlay": 3}
+        assert gwf.resolve_dims("nrow") == {"nrow": 10}
+        assert gwf.resolve_dims("ncol") == {"ncol": 20}
+        assert gwf.resolve_dims("nodes") == {"nodes": 600}
+        assert gwf.resolve_dims("ncpl") == {"ncpl": 200}
 
     def test_gwf_get_all_dimensions(self):
-        """Test that Gwf.get_all_dimensions() returns dimensions from Dis."""
+        """Test that Gwf.resolve_dims() returns dimensions from Dis."""
         from flopy4.mf6.gwf import Gwf
         from flopy4.mf6.gwf.dis import Dis
 
         dis = Dis(nlay=3, nrow=10, ncol=20)
         gwf = Gwf(name="test", dis=dis)
 
-        dims = gwf.get_all_dimensions()
+        dims = gwf.resolve_dims()
 
         assert dims == {
             "nlay": 3,
@@ -310,8 +383,8 @@ class TestComponentIntegration:
         gwf = Gwf(name="test", dis=dis)
 
         # Gwf should be able to resolve dimensions from Dis
-        assert gwf.resolve_dimension("nlay") == 3
-        assert gwf.resolve_dimension("nodes") == 600
+        assert gwf.resolve_dims("nlay") == {"nlay": 3}
+        assert gwf.resolve_dims("nodes") == {"nodes": 600}
 
         # Verify parent was set by xattree (use 'is' for identity, not '==' for equality)
         assert dis.parent is gwf
@@ -325,13 +398,13 @@ class TestComponentIntegration:
         gwf = Gwf(name="test", dis=dis)
 
         # First resolution
-        result1 = gwf.resolve_dimension("nlay")
+        result1 = gwf.resolve_dims("nlay")
         assert "nlay" in gwf._dimension_cache
         assert gwf._dimension_cache["nlay"] == 3
 
         # Second resolution should use cache
-        result2 = gwf.resolve_dimension("nlay")
-        assert result1 == result2 == 3
+        result2 = gwf.resolve_dims("nlay")
+        assert result1 == result2 == {"nlay": 3}
 
     def test_simulation_resolves_nper_from_tdis(self):
         """Test that Simulation can resolve nper from Tdis."""
@@ -342,7 +415,7 @@ class TestComponentIntegration:
         sim = Simulation(name="test", tdis=tdis)
 
         # Simulation should resolve nper from Tdis
-        assert sim.resolve_dimension("nper") == 10
+        assert sim.resolve_dims("nper") == {"nper": 10}
 
     def test_model_in_simulation_can_access_tdis_dimensions(self):
         """Test that models within simulation can access Tdis dimensions."""
@@ -358,11 +431,11 @@ class TestComponentIntegration:
         sim = Simulation(name="test", tdis=tdis, models={"test": gwf})
 
         # Model should access its own grid dimensions
-        assert gwf.resolve_dimension("nlay") == 3
-        assert gwf.resolve_dimension("nodes") == 600
+        assert gwf.resolve_dims("nlay") == {"nlay": 3}
+        assert gwf.resolve_dims("nodes") == {"nodes": 600}
 
         # Model should also access time dimensions from parent simulation
-        assert gwf.resolve_dimension("nper") == 10
+        assert gwf.resolve_dims("nper") == {"nper": 10}
 
     def test_package_resolves_both_grid_and_time_dimensions(self):
         """Test that models can resolve both grid and time dimensions."""
@@ -380,8 +453,80 @@ class TestComponentIntegration:
         sim = Simulation(name="test", tdis=tdis, models={"test": gwf})
 
         # Model should resolve grid dimensions from its Dis
-        assert gwf.resolve_dimension("nlay") == 3
-        assert gwf.resolve_dimension("nodes") == 600
+        assert gwf.resolve_dims("nlay") == {"nlay": 3}
+        assert gwf.resolve_dims("nodes") == {"nodes": 600}
 
         # Model should resolve time dimensions from parent Simulation → Tdis
-        assert gwf.resolve_dimension("nper") == 10
+        assert gwf.resolve_dims("nper") == {"nper": 10}
+
+    def test_gwf_resolve_multiple_dimensions(self):
+        """Test that Gwf can resolve multiple dimensions at once."""
+        from flopy4.mf6.gwf import Gwf
+        from flopy4.mf6.gwf.dis import Dis
+
+        dis = Dis(nlay=3, nrow=10, ncol=20)
+        gwf = Gwf(name="test", dis=dis)
+
+        # Request multiple explicit dimensions
+        result = gwf.resolve_dims("nlay", "nrow", "ncol")
+        assert result == {"nlay": 3, "nrow": 10, "ncol": 20}
+
+    def test_gwf_resolve_mix_explicit_computed(self):
+        """Test resolving mix of explicit and computed dimensions."""
+        from flopy4.mf6.gwf import Gwf
+        from flopy4.mf6.gwf.dis import Dis
+
+        dis = Dis(nlay=3, nrow=10, ncol=20)
+        gwf = Gwf(name="test", dis=dis)
+
+        # Request mix of explicit and computed
+        result = gwf.resolve_dims("nlay", "nodes", "ncol", "ncpl")
+        assert result == {"nlay": 3, "nodes": 600, "ncol": 20, "ncpl": 200}
+
+    def test_gwf_resolve_only_computed(self):
+        """Test resolving only computed dimensions."""
+        from flopy4.mf6.gwf import Gwf
+        from flopy4.mf6.gwf.dis import Dis
+
+        dis = Dis(nlay=3, nrow=10, ncol=20)
+        gwf = Gwf(name="test", dis=dis)
+
+        # Request only computed dimensions
+        result = gwf.resolve_dims("nodes", "ncpl")
+        assert result == {"nodes": 600, "ncpl": 200}
+
+    def test_gwf_resolve_mix_valid_invalid(self):
+        """Test resolving mix of valid and invalid dimensions."""
+        from flopy4.mf6.gwf import Gwf
+        from flopy4.mf6.gwf.dis import Dis
+
+        dis = Dis(nlay=3, nrow=10, ncol=20)
+        gwf = Gwf(name="test", dis=dis)
+
+        # Request mix - some valid, some invalid
+        result = gwf.resolve_dims("nlay", "nonexistent", "nodes", "invalid")
+        assert result == {"nlay": 3, "nodes": 600}
+        assert "nonexistent" not in result
+        assert "invalid" not in result
+
+    def test_model_resolve_grid_and_time_together(self):
+        """Test resolving both grid and time dimensions in one call."""
+        from flopy4.mf6.gwf import Gwf
+        from flopy4.mf6.gwf.dis import Dis
+        from flopy4.mf6.simulation import Simulation
+        from flopy4.mf6.tdis import Tdis
+
+        tdis = Tdis(nper=10)
+        dis = Dis(nlay=3, nrow=10, ncol=20)
+        gwf = Gwf(name="test", dis=dis)
+        sim = Simulation(name="test", tdis=tdis, models={"test": gwf})
+
+        # Request both grid and time dimensions together
+        result = gwf.resolve_dims("nlay", "nrow", "ncol", "nper", "nodes")
+        assert result == {
+            "nlay": 3,
+            "nrow": 10,
+            "ncol": 20,
+            "nper": 10,
+            "nodes": 600,
+        }


### PR DESCRIPTION
refining protocols introduced in #296 for the refactor described in #167 

- renamed `DimensionRegistry` → `DimensionResolver`
- renamed `DimensionRegistryMixin` → `DimensionResolverMixin`
- renamed `get_dimensions()` → `get_dims()`
- consolidated `resolve_dimension()` / `get_all_dimensions()` → `resolve_dims()`
- `resolve_dims()` accepts multiple (or no) dim names and returns dict for consistency:
  - `resolve_dims()` → all available dimensions
  - `resolve_dims('nlay')` → `{'nlay': 3}`
  - `resolve_dims('nlay', 'nrow')` → `{'nlay': 3, 'nrow': 10}`